### PR TITLE
feat: [IWP-102] add generateOID4VPSessionTranscriptCBOR method and update generateDeviceResponse family of methods

### DIFF
--- a/IOWalletProximity/IOWalletProximity.xcodeproj/project.pbxproj
+++ b/IOWalletProximity/IOWalletProximity.xcodeproj/project.pbxproj
@@ -119,6 +119,8 @@
 		3D179CBA2CB95A370061DFDC /* KeychainAccess in Frameworks */ = {isa = PBXBuildFile; productRef = 3D179CB92CB95A370061DFDC /* KeychainAccess */; settings = {ATTRIBUTES = (Required, ); }; };
 		3D179CBC2CB95EEB0061DFDC /* LibIso18013DAOKeyChain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D179CBB2CB95EDE0061DFDC /* LibIso18013DAOKeyChain.swift */; };
 		3D3263902D636B8B00E3976E /* SwiftASN1 in Frameworks */ = {isa = PBXBuildFile; productRef = 3D32638F2D636B8B00E3976E /* SwiftASN1 */; };
+		3DA71A882D8C503D00EC35EF /* OID4VPHandover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DA71A872D8C503400EC35EF /* OID4VPHandover.swift */; };
+		3DA71A8A2D8C573700EC35EF /* SessionTranscriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DA71A892D8C573000EC35EF /* SessionTranscriptTests.swift */; };
 		3DC072092D7F3BA1003C35A2 /* iOS13HKDF.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DC072082D7F3BA1003C35A2 /* iOS13HKDF.swift */; };
 		3DCFB9C92D7894E7001050C3 /* Proximity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DCFB9C82D7894E4001050C3 /* Proximity.swift */; };
 /* End PBXBuildFile section */
@@ -243,6 +245,8 @@
 		3D179CB12CB9079C0061DFDC /* LibIso18013UtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibIso18013UtilsTests.swift; sourceTree = "<group>"; };
 		3D179CB42CB924D90061DFDC /* LibIso18013DAOMemory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibIso18013DAOMemory.swift; sourceTree = "<group>"; };
 		3D179CBB2CB95EDE0061DFDC /* LibIso18013DAOKeyChain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibIso18013DAOKeyChain.swift; sourceTree = "<group>"; };
+		3DA71A872D8C503400EC35EF /* OID4VPHandover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OID4VPHandover.swift; sourceTree = "<group>"; };
+		3DA71A892D8C573000EC35EF /* SessionTranscriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionTranscriptTests.swift; sourceTree = "<group>"; };
 		3DC072082D7F3BA1003C35A2 /* iOS13HKDF.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOS13HKDF.swift; sourceTree = "<group>"; };
 		3DCFB9C82D7894E4001050C3 /* Proximity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Proximity.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -399,6 +403,7 @@
 		3ADB28FB2CC2507A0087018A /* ModelTests */ = {
 			isa = PBXGroup;
 			children = (
+				3DA71A892D8C573000EC35EF /* SessionTranscriptTests.swift */,
 				3ACBE9FF2CD28B1B00701457 /* DocumentErrorTests.swift */,
 				3ACBEA012CD2917700701457 /* ErrorsTests.swift */,
 				3ACBEA032CD2920F00701457 /* NameValueTests.swift */,
@@ -433,6 +438,7 @@
 		3D14E6452CAD8C0A00E15A46 /* IOWalletProximity */ = {
 			isa = PBXGroup;
 			children = (
+				3DA71A862D8C502900EC35EF /* OID4VP */,
 				3DCFB9C82D7894E4001050C3 /* Proximity.swift */,
 				3A868B572CBFC2DF00B35976 /* Proximity */,
 				3D179CB32CB924CF0061DFDC /* DAO */,
@@ -569,6 +575,14 @@
 				3D179CB42CB924D90061DFDC /* LibIso18013DAOMemory.swift */,
 			);
 			path = DAO;
+			sourceTree = "<group>";
+		};
+		3DA71A862D8C502900EC35EF /* OID4VP */ = {
+			isa = PBXGroup;
+			children = (
+				3DA71A872D8C503400EC35EF /* OID4VPHandover.swift */,
+			);
+			path = OID4VP;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -718,6 +732,7 @@
 				3D14E6472CAD8C0A00E15A46 /* IOWalletProximity.docc in Sources */,
 				3D14E6A72CAE9A1000E15A46 /* CoseKeyPrivate.swift in Sources */,
 				3D14E6882CAD944200E15A46 /* IssuerNameSpaces.swift in Sources */,
+				3DA71A882D8C503D00EC35EF /* OID4VPHandover.swift in Sources */,
 				3D179CAC2CB7BDC60061DFDC /* LibIso18013DAO.swift in Sources */,
 				3A405EEE2CAFDA050069998C /* DocumentError.swift in Sources */,
 				3D14E6A92CAE9AE600E15A46 /* ValidityInfo.swift in Sources */,
@@ -805,6 +820,7 @@
 				3ADB28F42CC106920087018A /* DeviceEngagementTests.swift in Sources */,
 				3ACBEA042CD2920F00701457 /* NameValueTests.swift in Sources */,
 				3ADB28FD2CC252CE0087018A /* ErrorHandlerTests.swift in Sources */,
+				3DA71A8A2D8C573700EC35EF /* SessionTranscriptTests.swift in Sources */,
 				3A652A2A2CAE9B3400B0D6E4 /* DrivingPrivilegesTests.swift in Sources */,
 				3A652A262CAE97C700B0D6E4 /* DeviceResponseTests.swift in Sources */,
 				3ACBE9FA2CD2898400701457 /* DictionaryExtensionsTests.swift in Sources */,

--- a/IOWalletProximity/IOWalletProximity/OID4VP/OID4VPHandover.swift
+++ b/IOWalletProximity/IOWalletProximity/OID4VP/OID4VPHandover.swift
@@ -1,0 +1,46 @@
+//
+//  OID4VPHandover.swift
+//  IOWalletProximity
+//
+//  Created by Antonio Caparello on 20/03/25.
+//
+
+internal import SwiftCBOR
+internal import Crypto
+
+struct OID4VPHandover : CBOREncodable {
+    let clientId: String
+    let responseUri: String
+    let authorizationRequestNonce: String
+    let mdocGeneratedNonce: String
+    
+    func toCBOR(options: SwiftCBOR.CBOROptions) -> SwiftCBOR.CBOR {
+        let encodedClientId = CBOR(arrayLiteral: [
+            .utf8String(clientId),
+            .utf8String(mdocGeneratedNonce)
+        ]).encode()
+        
+        let encodedResponseUri = CBOR(arrayLiteral: [
+            .utf8String(responseUri),
+            .utf8String(mdocGeneratedNonce)
+        ]).encode()
+        
+        let clientIdChecksum = calcSHA256Hash(encodedClientId)
+        let responseUriChecksum = calcSHA256Hash(encodedResponseUri)
+        
+        return CBOR(arrayLiteral:
+            .byteString(clientIdChecksum),
+            .byteString(responseUriChecksum),
+            .utf8String(authorizationRequestNonce)
+        )
+    }
+    
+    func calcSHA256Hash( _ data: [UInt8] ) -> [UInt8] {
+        var sha256 = SHA256()
+        sha256.update(data: data)
+        let hash = sha256.finalize()
+        
+        return Array(hash)
+    }
+    
+}

--- a/IOWalletProximity/IOWalletProximity/Proximity.swift
+++ b/IOWalletProximity/IOWalletProximity/Proximity.swift
@@ -69,12 +69,19 @@ public class Proximity: @unchecked Sendable {
     }
     
     
-    //  Generate session transcript with OID4VPHandover
-    //  - Parameters:
-    //      - clientId: clientId
-    //      - responseUri: responseUri
-    //      - authorizationRequestNonce: authorizationRequestNonce
-    //      - mdocGeneratedNonce: mdocGeneratedNonce
+    
+   /**
+    * Generate session transcript with OID4VPHandover
+    * This method is used for ISO 18013-7 OID4VP flow.
+    *
+    * - Parameters:
+    *   - clientId: Authorization Request 'client_id'
+    *   - responseUri: Authorization Request 'response_uri'
+    *   - authorizationRequestNonce: Authorization Request 'nonce'
+    *   - mdocGeneratedNonce: cryptographically random number with sufficient entropy
+    *
+    * - Returns: A CBOR-encoded SessionTranscript object
+    */
     public func generateOID4VPSessionTranscriptCBOR(
         clientId: String,
         responseUri: String,
@@ -413,6 +420,19 @@ public class Proximity: @unchecked Sendable {
     }
     
     
+    /**
+     * Builds a response document using a SessionTranscript for authentication.
+     * This method is used specifically for OID4VP flows.
+     *
+     * - Parameters:
+     *   - request: Dictionary mapping namespaces to element identifiers which want to share
+     *   - issuerSigned: The issuer-signed data for the document
+     *   - deviceKey: The private key used for signing the device authentication
+     *   - sessionTranscript: The session transcript containing the handover data
+     *
+     * - Returns: A Document object if document creation succeeded, nil otherwise
+     */
+    
     func buildResponseDocument(
         request: [String: [String: Bool]],
         issuerSigned: IssuerSigned,
@@ -444,6 +464,20 @@ public class Proximity: @unchecked Sendable {
                 return nil
             }
         }
+    
+    
+    /**
+     * Builds a response document using a SessionEncryption for authentication.
+     * This method is used for traditional ISO 18013-5 flows.
+     *
+     * - Parameters:
+     *   - request: Dictionary mapping namespaces to element identifiers which want to share
+     *   - issuerSigned: The issuer-signed data for the document
+     *   - deviceKey: The private key used for signing the device authentication
+     *   - sessionEncryption: The session encryption containing keys and transcript data
+     *
+     * - Returns: A Document object if document creation succeeded, nil otherwise
+     */
     
     func buildResponseDocument(
         request: [String: [String: Bool]],

--- a/IOWalletProximity/IOWalletProximity/Proximity/Security/MdocAuthentication.swift
+++ b/IOWalletProximity/IOWalletProximity/Proximity/Security/MdocAuthentication.swift
@@ -52,16 +52,23 @@ struct MdocAuthentication {
 	///   - deviceNameSpacesRawData: device-name spaces raw data. Usually is a CBOR-encoded empty dictionary
 	///   - bUseDeviceSign: Specify true for device authentication (false is default)
 	/// - Returns: DeviceAuth instance
-	public func getDeviceAuthForTransfer(docType: String, deviceNameSpacesRawData: [UInt8] = [0xA0], dauthMethod: DeviceAuthMethod) throws -> DeviceAuth? {
-		let da = DeviceAuthentication(sessionTranscript: transcript, docType: docType, deviceNameSpacesRawData: deviceNameSpacesRawData)
-		let contentBytes = da.toCBOR(options: CBOROptions()).taggedEncoded.encode(options: CBOROptions())
-		let coseRes: Cose
-		if dauthMethod == .deviceSignature {
-			coseRes = try Cose.makeDetachedCoseSign1(payloadData: Data(contentBytes), deviceKey: authKeys.privateKey, alg: .es256)
-		} else {
+    public func getDeviceAuthForTransfer(docType: String, deviceNameSpacesRawData: [UInt8] = [0xA0], dauthMethod: DeviceAuthMethod) throws -> DeviceAuth? {
+        if dauthMethod == .deviceSignature {
+            return try MdocAuthentication.getDeviceAuthForTransferSignature(transcript: transcript, docType: docType, deviceNameSpacesRawData: deviceNameSpacesRawData, privateKey: authKeys.privateKey)
+        } else {
+            let da = DeviceAuthentication(sessionTranscript: transcript, docType: docType, deviceNameSpacesRawData: deviceNameSpacesRawData)
+            let contentBytes = da.toCBOR(options: CBOROptions()).taggedEncoded.encode(options: CBOROptions())
+           
             guard let symmetricKey = try self.makeMACKeyAggrementAndDeriveKey(deviceAuth: da) else { return nil}
-            coseRes = Cose.makeDetachedCoseMac0(payloadData: Data(contentBytes), key: symmetricKey, alg: .hmac256)
-	    }
-		return DeviceAuth(coseMacOrSignature: coseRes)
-	}
+            let coseRes: Cose = Cose.makeDetachedCoseMac0(payloadData: Data(contentBytes), key: symmetricKey, alg: .hmac256)
+            return DeviceAuth(coseMacOrSignature: coseRes)
+        }
+    }
+    
+    public static func getDeviceAuthForTransferSignature(transcript: SessionTranscript, docType: String, deviceNameSpacesRawData: [UInt8] = [0xA0], privateKey: CoseKeyPrivate) throws -> DeviceAuth? {
+        let da = DeviceAuthentication(sessionTranscript: transcript, docType: docType, deviceNameSpacesRawData: deviceNameSpacesRawData)
+        let contentBytes = da.toCBOR(options: CBOROptions()).taggedEncoded.encode(options: CBOROptions())
+        let coseRes: Cose = try Cose.makeDetachedCoseSign1(payloadData: Data(contentBytes), deviceKey: privateKey, alg: .es256)
+        return DeviceAuth(coseMacOrSignature: coseRes)
+    }
 }

--- a/IOWalletProximity/IOWalletProximity/Proximity/Security/SessionTranscript.swift
+++ b/IOWalletProximity/IOWalletProximity/Proximity/Security/SessionTranscript.swift
@@ -20,6 +20,26 @@ internal import SwiftCBOR
 	}
 }
 
+extension SessionTranscript: CBORDecodable {
+    init?(cbor: SwiftCBOR.CBOR) {
+        guard case .array(let array) = cbor else { return nil }
+        
+        if case .null = array[0] {
+            devEngRawData = nil
+        } else {
+            devEngRawData = array[0].decodeTaggedBytes()
+        }
+        
+        if case .null = array[1] {
+            eReaderRawData = nil
+        } else {
+            eReaderRawData = array[1].decodeTaggedBytes()
+        }
+        
+        handOver = array[2]
+    }
+}
+
 extension SessionTranscript: CBOREncodable {
 	public func toCBOR(options: CBOROptions) -> CBOR {
 		return .array([devEngRawData?.taggedEncoded ?? CBOR.null, eReaderRawData?.taggedEncoded ?? CBOR.null, handOver])

--- a/IOWalletProximity/IOWalletProximityTests/ModelTests/SessionTranscriptTests.swift
+++ b/IOWalletProximity/IOWalletProximityTests/ModelTests/SessionTranscriptTests.swift
@@ -1,0 +1,46 @@
+//
+//  SessionTranscriptTests.swift
+//  IOWalletProximity
+//
+//  Created by Antonio Caparello on 20/03/25.
+//
+
+import XCTest
+import Security
+internal import SwiftCBOR
+
+@testable import IOWalletProximity
+
+class SessionTranscriptTests: XCTestCase {
+    func testSessionTranscriptOID4VP() {
+        let clientId = "RANDOM CLIENT ID"
+        let responseUri = "RANDOM URI"
+        let authorizationRequestNonce = "AUTH NONCE"
+        let mdocNonce = "MDOC NONCE"
+        
+        let generatedOid4vpSessionTranscript = "g/b2g1ggxUpjPEK7GoBmVsdwEzkQzlL9Kjd16xaMk4qmS5XhMlFYIPQlZ089PEspsVYm/PjJRfWZ5wLXMFiD8onG/RgRbhPLakFVVEggTk9OQ0U="
+        
+        let oid4vpSessionTranscript = Proximity().generateOID4VPSessionTranscriptCBOR(
+            clientId: clientId,
+            responseUri: responseUri,
+            authorizationRequestNonce: authorizationRequestNonce,
+            mdocGeneratedNonce: mdocNonce
+        )
+        
+        XCTAssertEqual(Data(oid4vpSessionTranscript).base64EncodedString(), generatedOid4vpSessionTranscript)
+        
+        let decodedOid4vpSessionTranscript = SessionTranscript(data: oid4vpSessionTranscript)
+        
+        guard case .array(let handOver) = decodedOid4vpSessionTranscript?.handOver else {
+            XCTFail("failed to decode handOver")
+            return
+        }
+        
+        guard case .utf8String(let decodedAuthorizationRequestNonce) = handOver[2] else {
+            XCTFail("failed to decode authorizationRequestNonce")
+            return
+        }
+        
+        XCTAssertEqual(decodedAuthorizationRequestNonce, authorizationRequestNonce)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # iso18013-ios
 
-### Proximity
-
 The library offers a specific set of functions to handle BLE proximity as specified by iso-18013
 
+### ISO18013-5 Proximity
 
 #### Proximity.shared.proximityHandler
 
@@ -43,23 +42,6 @@ let qrCode = Proximity.shared.start()
 //  Stops the BLE manager and closes connections.
 
 Proximity.shared.stop()
-```
-
-
-#### Proximity.shared.generateOID4VPSessionTranscriptCBOR
-```swift
-//  Generate session transcript with OID4VPHandover
-//  - Parameters:
-//      - clientId: clientId
-//      - responseUri: responseUri
-//      - authorizationRequestNonce: authorizationRequestNonce
-//      - mdocGeneratedNonce: mdocGeneratedNonce
-public func generateOID4VPSessionTranscriptCBOR(
-    clientId: String,
-    responseUri: String,
-    authorizationRequestNonce: String,
-    mdocGeneratedNonce: String
-) -> [UInt8] 
 ```
 
 
@@ -137,4 +119,59 @@ let response = Proximity.shared.generateDeviceResponse(allowed: allowed, items: 
 let deviceResponse: [UInt8] = /*result of generateDeviceResponse*/
 
 Proximity.shared.dataPresentation(allowed: allowed, deviceResponse)
+```
+
+### ISO18013-7 Remote Presentation (OpenID4VP)
+
+
+#### Proximity.shared.generateOID4VPSessionTranscriptCBOR
+```swift
+/**
+    * Generate session transcript with OID4VPHandover
+    * This method is used for ISO 18013-7 OID4VP flow.
+    *
+    * - Parameters:
+    *   - clientId: Authorization Request 'client_id'
+    *   - responseUri: Authorization Request 'response_uri'
+    *   - authorizationRequestNonce: Authorization Request 'nonce'
+    *   - mdocGeneratedNonce: cryptographically random number with sufficient entropy
+    *
+    * - Returns: A CBOR-encoded SessionTranscript object
+*/
+public func generateOID4VPSessionTranscriptCBOR(
+    clientId: String,
+    responseUri: String,
+    authorizationRequestNonce: String,
+    mdocGeneratedNonce: String
+) -> [UInt8] 
+```
+
+#### Example
+
+```swift
+let mdocGeneratedNonce: String = /*generate cryptographically random number with sufficient entropy*/
+
+let openId4VpRequest = /*retrive openId4VpRequest using mdocGeneratedNonce*/
+
+let sessionTranscript = Proximity.shared.generateOID4VPSessionTranscriptCBOR(
+    clientId: openId4VpRequest.client_id,
+    responseUri: openId4VpRequest.response_uri,
+    authorizationRequestNonce: openId4VpRequest.nonce,
+    mdocGeneratedNonce: mdocGeneratedNonce
+)
+//Map of [documentType: [nameSpace: [elementIdentifier: allowed]]]
+let items: [String: [String: [String: Bool]]] = [:] //items should contain all the items received in the openId4VpRequest.
+
+//Map of [documentType : (issuerSigned, deviceKey)]
+var documentMap: [String: ([UInt8], SecKey)] = [:]
+
+let deviceResponse = Proximity.shared.generateDeviceResponseFromDataWithSecKey(
+    allowed: true,
+    items: items, 
+    documents: documentMap,
+    sessionTranscript: sessionTranscript
+)
+
+//send deviceResponse to OpenID4VP backend
+
 ```

--- a/README.md
+++ b/README.md
@@ -46,13 +46,64 @@ Proximity.shared.stop()
 ```
 
 
-#### Proximity.shared.generateDeviceResponse
+#### Proximity.shared.generateOID4VPSessionTranscriptCBOR
+```swift
+//  Generate session transcript with OID4VPHandover
+//  - Parameters:
+//      - clientId: clientId
+//      - responseUri: responseUri
+//      - authorizationRequestNonce: authorizationRequestNonce
+//      - mdocGeneratedNonce: mdocGeneratedNonce
+public func generateOID4VPSessionTranscriptCBOR(
+    clientId: String,
+    responseUri: String,
+    authorizationRequestNonce: String,
+    mdocGeneratedNonce: String
+) -> [UInt8] 
+```
+
+
+#### Proximity.shared.generateDeviceResponseFromJsonWithSecKey
+```swift
+//  Generate response to request for data from the reader.
+//  - Parameters:
+//      - allowed: User has allowed the verification process
+//      - items: json of map of [documentType: [nameSpace: [elementIdentifier: allowed]]] as String
+//      - documents: Map of documents. Key is docType, first item is issuerSigned as cbor and second item is SecKey
+//      - sessionTranscript: optional CBOR encoded session transcript
+public func generateDeviceResponseFromJsonWithSecKey(
+    allowed: Bool,
+    items: String?,
+    documents: [String: ([UInt8], SecKey)]?,
+    sessionTranscript: [UInt8]?
+) -> [UInt8]?
+```
+
+#### Proximity.shared.generateDeviceResponseFromDataWithSecKey
+```swift
+//  Generate response to request for data from the reader.
+//  - Parameters:
+//      - allowed: User has allowed the verification process
+//      - items: json of map of [documentType: [nameSpace: [elementIdentifier: allowed]]]
+//      - documents: Map of documents. Key is docType, first item is issuerSigned as cbor and second item is SecKey
+//      - sessionTranscript: optional CBOR encoded session transcript
+public func generateDeviceResponseFromDataWithSecKey(
+    allowed: Bool,
+    items: [String: [String: [String: Bool]]]?,
+    documents: [String: ([UInt8], SecKey)]?,
+    sessionTranscript: [UInt8]?
+) -> [UInt8]?
+```
+
+
+#### Proximity.shared.generateDeviceResponseFromData
 ```swift
 //  Generate response to request for data from the reader.
 //  - Parameters:
 //      - allowed: User has allowed the verification process
 //      - items: Map of [documentType: [nameSpace: [elementIdentifier: allowed]]]
 //      - documents: Map of documents. Key is docType, first item is issuerSigned as cbor and second item is CoseKeyPrivate encoded
+//      - sessionTranscript: optional CBOR encoded session transcript
 
 let items: [String: [String: [String: Bool]]] = [:]
 


### PR DESCRIPTION
add generateOID4VPSessionTranscriptCBOR method
add sessionTranscript parameter to generateDeviceResponse family of methods

## List of changes proposed in this pull request

- Created OID4VPHandover structure to simplify CBOR-encoding
- Added generateOID4VPSessionTranscriptCBOR to utilize OID4VPHandover to create a OID4VP session transcript

## How to test

I've tested using SessionTranscriptTests.testSessionTranscriptOID4VP

It generates a test SessionTranscript object using specified parameters. Then it verifies if the SessionTranscript handOver is properly encoded and contains all the necessary fields.


