### PR TITLE
refactor: [IWP-108] Simplify onDocumentRequestReceived request management

### DIFF
--- a/IOWalletProximityExample/IOWalletProximityExample/View/QRCodeView.swift
+++ b/IOWalletProximityExample/IOWalletProximityExample/View/QRCodeView.swift
@@ -68,25 +68,23 @@ struct QRCodeView: View {
                     .scaleEffect(4)
             }
             
-            if case .onDocumentRequestReceived(let request) = proximityEvent {
+            if case .onDocumentRequestReceived(let request, let json) = proximityEvent {
                 
                 let req:  [String: [String: [String]]] = {
                     var popupRequest : [String: [String: [String]]] = [:]
                     
-                     request?.request?.forEach({
-                        item in
-                         
-                         var subReq: [String: [String]] = [:]
-                         
-                         item.nameSpaces.keys.forEach({
-                             nameSpace in
-                             subReq[nameSpace] =
-                                 item.nameSpaces[nameSpace]?.keys.map({$0})
-                         })
-                         
-                         popupRequest[item.docType] = subReq
+                    (request["request"] as? [String: AnyHashable])?.forEach({
+                        docType, nameSpaces in
+                        var subReq: [String: [String]] = [:]
+                        
+                        (nameSpaces as? [String: AnyHashable])?.forEach({
+                            nameSpace, items in
+                            subReq[nameSpace] = (items as? [String: AnyHashable])?.keys.map({$0})
+                        })
+                        
+                        popupRequest[docType] = subReq
+                        
                     })
-                    
                     return popupRequest
                     
                     

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The library offers a specific set of functions to handle BLE proximity as specif
 public enum ProximityEvents {
     case onBleStart
     case onBleStop
-    case onDocumentRequestReceived(request:  (request: [(docType: String, nameSpaces: [String: [String: Bool]])]?, isAuthenticated: Bool)?)
+    case onDocumentRequestReceived(request: [String: AnyHashable], json: String?)
     case onDocumentPresentationCompleted
     case onError(error: Error)
     case onLoading
@@ -23,6 +23,56 @@ public enum ProximityEvents {
     print(event)
 }
 ```
+
+#### Proximity.shared.ProximityEvents.onDocumentRequestReceived(request: [String: AnyHashable], json: String?)
+
+* **request** is a json object.
+* **json** is **request** as string.
+
+Here an example:
+
+```json
+{
+  "isAuthenticated": false,
+  "request": {
+    "eu.europa.ec.eudi.pid.1": {
+      "eu.europa.ec.eudi.pid.1": {
+        "resident_street": false,
+        "birth_country": false,
+        "birth_city": false,
+        "given_name": false,
+        "nationality": false,
+        "issuance_date": false,
+        "issuing_authority": false,
+        "resident_state": false,
+        "portrait_capture_date": false,
+        "birth_date": false,
+        "gender": false,
+        "portrait": false,
+        "birth_place": false,
+        "given_name_birth": false,
+        "family_name_birth": false,
+        "administrative_number": false,
+        "age_birth_year": false,
+        "resident_address": false,
+        "issuing_country": false,
+        "family_name": false,
+        "resident_city": false,
+        "resident_country": false,
+        "document_number": false,
+        "resident_house_number": false,
+        "expiry_date": false,
+        "birth_state": false,
+        "issuing_jurisdiction": false,
+        "age_in_years": false,
+        "resident_postal_code": false
+      }
+    }
+  }
+}
+```
+
+
 
 
 #### Proximity.shared.start


### PR DESCRIPTION
## Short description

Simplify onDocumentRequestReceived request management

Parameters for onDocumentRequestReceived are:
* **request** : json object representing DeviceRequest.
* **json** : **request** as string.

Example value:

```json
{
  "isAuthenticated": false,
  "request": {
    "eu.europa.ec.eudi.pid.1": {
      "eu.europa.ec.eudi.pid.1": {
        "resident_street": false,
        "birth_country": false,
        "birth_city": false,
        "given_name": false,
        "nationality": false,
        "issuance_date": false,
        "issuing_authority": false,
        "resident_state": false,
        "portrait_capture_date": false,
        "birth_date": false,
        "gender": false,
        "portrait": false,
        "birth_place": false,
        "given_name_birth": false,
        "family_name_birth": false,
        "administrative_number": false,
        "age_birth_year": false,
        "resident_address": false,
        "issuing_country": false,
        "family_name": false,
        "resident_city": false,
        "resident_country": false,
        "document_number": false,
        "resident_house_number": false,
        "expiry_date": false,
        "birth_state": false,
        "issuing_jurisdiction": false,
        "age_in_years": false,
        "resident_postal_code": false
      }
    }
  }
}
```

## List of changes proposed in this pull request

- Changed signature for **onDocumentRequestReceived** in **ProximityEvents** enum
- Updated example app to reflect changes
- Updated README.md to reflect changes

## How to test

```bash
bundle install
cd IOWalletProximityExample
bundler exec pod update
```

Open IOWalletProximityExample\IOWalletProximityExample.xcworkspace using Xcode.
