### PR TITLE
fix: [IWP-109] Generate device response with non-null session transcript

### DIFF
--- a/IOWalletProximity/IOWalletProximity/Proximity.swift
+++ b/IOWalletProximity/IOWalletProximity/Proximity.swift
@@ -197,9 +197,18 @@ public class Proximity: @unchecked Sendable {
         var requestedDocuments = [Document]()
         var docErrors = [[String: UInt64]]()
         
-        guard let sessionEncryption = proximityListener?.sessionEncryption else {
-            return nil
+        let _sessionTranscript: SessionTranscript
+        
+        if let sessionTranscript = sessionTranscript {
+            _sessionTranscript = sessionTranscript
         }
+        else {
+            guard let sessionEncryption = proximityListener?.sessionEncryption else {
+                return nil
+            }
+            _sessionTranscript = sessionEncryption.transcript
+        }
+      
         
         guard let items = items else {
             return nil
@@ -227,7 +236,7 @@ public class Proximity: @unchecked Sendable {
                 return
             }
             
-            if let responseDocument = buildResponseDocument(request: request, issuerSigned: issuerSigned, deviceKey: deviceKey, sessionTranscript:  sessionTranscript ?? sessionEncryption.transcript) {
+            if let responseDocument = buildResponseDocument(request: request, issuerSigned: issuerSigned, deviceKey: deviceKey, sessionTranscript:  _sessionTranscript) {
                 
                 requestedDocuments.append(responseDocument)
             }

--- a/IOWalletProximity/IOWalletProximityTests/LibIso18013DAOTests.swift
+++ b/IOWalletProximity/IOWalletProximityTests/LibIso18013DAOTests.swift
@@ -37,6 +37,110 @@ final class LibIso18013DAOTests: XCTestCase {
         }
     }
     
+    func testGenerateDeviceResponse() {
+        
+        guard let documentData = Data(base64Encoded: DocumentTestData.issuerSignedDocument1)?.bytes else {
+            XCTFail("document data must be valid")
+            return
+        }
+        
+        guard let deviceKeyRaw = Data(base64Encoded: DocumentTestData.devicePrivateKey)?.bytes else {
+            XCTFail("device key must be valid")
+            return
+        }
+        
+        guard let document = ProximityDocument(docType: DocType.euPid.rawValue, issuerSigned: documentData, deviceKeyRaw: deviceKeyRaw) else {
+            XCTFail("document must be valid")
+            return
+        }
+        
+        let documents: [ProximityDocument] = [
+            document
+        ]
+        
+        
+        let items = [
+            "eu.europa.ec.eudi.pid.1": [
+                "eu.europa.ec.eudi.pid.1" :
+                    [
+                        "birth_country": true,
+                        "given_name_birth": true,
+                        "birth_state": true,
+                        "family_name": true,
+                        "resident_postal_code": true,
+                        "birth_date": true,
+                        "resident_city": true,
+                        "issuing_authority": true,
+                        "nationality": true,
+                        "document_number": true,
+                        "resident_street": true,
+                        "issuing_jurisdiction": true,
+                        "given_name": true,
+                        "age_in_years": true,
+                        "family_name_birth": true,
+                        "issuing_country": true,
+                        "portrait": true,
+                        "expiry_date": true,
+                        "administrative_number": true,
+                        "issuance_date": true,
+                        "resident_state": true,
+                        "gender": true,
+                        "age_birth_year": true,
+                        "portrait_capture_date": true,
+                        "resident_house_number": true,
+                        "birth_place": true,
+                        "resident_address": true,
+                        "resident_country": true,
+                        "birth_city": true
+                    ]
+            ]
+        ]
+        
+       let sessionTranscript = Proximity.shared.generateOID4VPSessionTranscriptCBOR(clientId: "clientId", responseUri: "responseUri", authorizationRequestNonce: "authorizationRequestNonce", mdocGeneratedNonce: "mdocNonce")
+        
+        
+        guard let deviceResponseRaw = Proximity.shared.generateDeviceResponse(allowed: true, items: items, documents: documents, sessionTranscript: sessionTranscript) else {
+            XCTFail("deviceResponse must be valid")
+            return
+        }
+        
+        guard let deviceResponse = DeviceResponse(data: deviceResponseRaw) else {
+            XCTFail("deviceResponse must be valid")
+            return
+        }
+        
+        let deviceResponseItems = deviceResponse.documents?.map({
+            doc in
+            return doc.issuerSigned.issuerNameSpaces?.nameSpaces.map({
+                key, value in
+                return value.map({$0.elementIdentifier})
+            })
+        }).reduce([], {
+            return $0 + ($1 ?? [])
+        }).reduce([], {
+            return $0 + $1
+        }) ?? []
+        
+        let deviceResponseErrorItems = deviceResponse.documents?.map({
+            doc in
+            return doc.errors?.errors.map({
+                key, value in
+                return value.map({$0.key})
+            })
+        }).reduce([], {
+            return $0 + ($1 ?? [])
+        }).reduce([], {
+            return $0 + $1
+        }) ?? []
+        
+        //ensure each requested item is contained in deviceResponse valid items or error items
+        items.reduce([], { $0 + $1.value.reduce([], { $0 + $1.value.map({$0.key}) })})
+            .forEach({
+                item in
+                XCTAssert(deviceResponseItems.contains(item) || deviceResponseErrorItems.contains(item))
+        })
+    }
+    
     func doTestStoreDocument(dao: LibIso18013DAOProtocol) {
         let documentName = "Patente"
         guard let documentData = Data(base64Encoded: DocumentTestData.issuerSignedDocument1) else {


### PR DESCRIPTION
## Short description

Fix bug occurring when generate device response was called with non-null session transcript

## List of changes proposed in this pull request

- Improve checks on generateDeviceResponse when session transcript is not null
- Add test for generateDeviceResponse with custom session transcript

## How to test
```
bundle install
cd IOWalletProximityExample
bundler exec pod update
```

Open IOWalletProximityExample\IOWalletProximityExample.xcworkspace using Xcode.
