### PR TITLE
refactor: [IWP-110] Improved error handling for Proximity methods

### DIFF
--- a/IOWalletProximity/IOWalletProximity.xcodeproj/project.pbxproj
+++ b/IOWalletProximity/IOWalletProximity.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		3DA71A8A2D8C573700EC35EF /* SessionTranscriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DA71A892D8C573000EC35EF /* SessionTranscriptTests.swift */; };
 		3DC072092D7F3BA1003C35A2 /* iOS13HKDF.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DC072082D7F3BA1003C35A2 /* iOS13HKDF.swift */; };
 		3DCFB9C92D7894E7001050C3 /* Proximity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DCFB9C82D7894E4001050C3 /* Proximity.swift */; };
+		3DE097F62DA7D4D3005C83FD /* ProximityDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE097F52DA7D4CB005C83FD /* ProximityDocumentTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -251,6 +252,7 @@
 		3DA71A892D8C573000EC35EF /* SessionTranscriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionTranscriptTests.swift; sourceTree = "<group>"; };
 		3DC072082D7F3BA1003C35A2 /* iOS13HKDF.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOS13HKDF.swift; sourceTree = "<group>"; };
 		3DCFB9C82D7894E4001050C3 /* Proximity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Proximity.swift; sourceTree = "<group>"; };
+		3DE097F52DA7D4CB005C83FD /* ProximityDocumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProximityDocumentTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -406,6 +408,7 @@
 		3ADB28FB2CC2507A0087018A /* ModelTests */ = {
 			isa = PBXGroup;
 			children = (
+				3DE097F52DA7D4CB005C83FD /* ProximityDocumentTests.swift */,
 				3DA71A892D8C573000EC35EF /* SessionTranscriptTests.swift */,
 				3ACBE9FF2CD28B1B00701457 /* DocumentErrorTests.swift */,
 				3ACBEA012CD2917700701457 /* ErrorsTests.swift */,
@@ -828,6 +831,7 @@
 				3A652A2A2CAE9B3400B0D6E4 /* DrivingPrivilegesTests.swift in Sources */,
 				3A652A262CAE97C700B0D6E4 /* DeviceResponseTests.swift in Sources */,
 				3ACBE9FA2CD2898400701457 /* DictionaryExtensionsTests.swift in Sources */,
+				3DE097F62DA7D4D3005C83FD /* ProximityDocumentTests.swift in Sources */,
 				3ACBEA002CD28B1B00701457 /* DocumentErrorTests.swift in Sources */,
 				3ADB29032CC2580E0087018A /* UInt32ExtensionsTests.swift in Sources */,
 				3D179CAE2CB82CCA0061DFDC /* LibIso18013DAOTests.swift in Sources */,

--- a/IOWalletProximity/IOWalletProximity/Proximity.swift
+++ b/IOWalletProximity/IOWalletProximity/Proximity.swift
@@ -69,7 +69,6 @@ public class Proximity: @unchecked Sendable {
             return qrCode
         }
         catch {
-            proximityHandler?(.onError(error: error))
             throw ProximityError.error(error: error)
         }
     }
@@ -80,7 +79,6 @@ public class Proximity: @unchecked Sendable {
     //      - deviceResponse: deviceResponse as cbor encoded
     public func dataPresentation(allowed: Bool, _ deviceResponse: [UInt8]) throws {
         guard let proximityListener = self.proximityListener else {
-            throw Null
             throw ProximityError.nullObject(objectName: "proximityListener")
         }
         

--- a/IOWalletProximity/IOWalletProximity/Proximity/ProximityDocument.swift
+++ b/IOWalletProximity/IOWalletProximity/Proximity/ProximityDocument.swift
@@ -21,6 +21,11 @@ public class ProximityDocument {
             return nil
         }
         
+        if !ProximityDocument.isIssuerSignedValid(issuerSigned) {
+            //issuerSigned decoding failed
+            return nil
+        }
+        
         self.init(docType: docType, issuerSigned: issuerSigned, deviceKey: deviceKey)
     }
     
@@ -29,6 +34,12 @@ public class ProximityDocument {
         guard let deviceKey = CoseKeyPrivate.init(crv: .p256, secKey: deviceKeySecKey) else {
             return nil
         }
+        
+        if !ProximityDocument.isIssuerSignedValid(issuerSigned) {
+            //issuerSigned decoding failed
+            return nil
+        }
+        
         
         self.init(docType: docType, issuerSigned: issuerSigned, deviceKey: deviceKey)
     }
@@ -40,7 +51,21 @@ public class ProximityDocument {
             return nil
         }
         
+        if !ProximityDocument.isIssuerSignedValid(issuerSigned) {
+            //issuerSigned decoding failed
+            return nil
+        }
+        
+        
         self.init(docType: docType, issuerSigned: issuerSigned, deviceKey: deviceKey)
+    }
+    
+    private static func isIssuerSignedValid(_ issuerSigned: [UInt8]) -> Bool {
+        guard let _ = IssuerSigned(data: issuerSigned) else {
+            return false
+        }
+        
+        return true
     }
     
     private init(docType: String, issuerSigned: [UInt8], deviceKey: CoseKeyPrivate) {

--- a/IOWalletProximity/IOWalletProximityTests/LibIso18013DAOTests.swift
+++ b/IOWalletProximity/IOWalletProximityTests/LibIso18013DAOTests.swift
@@ -99,7 +99,7 @@ final class LibIso18013DAOTests: XCTestCase {
        let sessionTranscript = Proximity.shared.generateOID4VPSessionTranscriptCBOR(clientId: "clientId", responseUri: "responseUri", authorizationRequestNonce: "authorizationRequestNonce", mdocGeneratedNonce: "mdocNonce")
         
         
-        guard let deviceResponseRaw = Proximity.shared.generateDeviceResponse(allowed: true, items: items, documents: documents, sessionTranscript: sessionTranscript) else {
+        guard case .success(let deviceResponseRaw) = Proximity.shared.generateDeviceResponse(allowed: true, items: items, documents: documents, sessionTranscript: sessionTranscript) else {
             XCTFail("deviceResponse must be valid")
             return
         }

--- a/IOWalletProximity/IOWalletProximityTests/ModelTests/ProximityDocumentTests.swift
+++ b/IOWalletProximity/IOWalletProximityTests/ModelTests/ProximityDocumentTests.swift
@@ -1,0 +1,58 @@
+//
+//  ProximityDocumentTests.swift
+//  IOWalletProximity
+//
+//  Created by Antonio Caparello on 10/04/25.
+//
+
+
+import XCTest
+import Security
+internal import SwiftCBOR
+
+@testable import IOWalletProximity
+
+class ProimityDocumentTests: XCTestCase {
+ 
+    func testConstructorWithDeviceKeyRaw() {
+        
+        guard let documentData = Data(base64Encoded: DocumentTestData.issuerSignedDocument1)?.bytes else {
+            XCTFail("document data must be valid")
+            return
+        }
+        
+        guard let deviceKeyRaw = Data(base64Encoded: DocumentTestData.devicePrivateKey)?.bytes else {
+            XCTFail("device key must be valid")
+            return
+        }
+        
+        guard let document = ProximityDocument(docType: DocType.euPid.rawValue, issuerSigned: documentData, deviceKeyRaw: deviceKeyRaw) else {
+            XCTFail("document must be valid")
+            return
+        }
+        
+        XCTAssert(document.docType == DocType.euPid.rawValue)
+        
+    }
+    
+    func testConstructorWithNotValidIssuerSigned() {
+        //DocumentTestData.issuerSignedDocument1 is stored as base64. It can't be converted to bytes like this.
+        let documentData = Data(DocumentTestData.issuerSignedDocument1.utf8).bytes
+        
+        guard let deviceKeyRaw = Data(base64Encoded: DocumentTestData.devicePrivateKey)?.bytes else {
+            XCTFail("device key must be valid")
+            return
+        }
+        
+        let document = ProximityDocument(docType: DocType.euPid.rawValue, issuerSigned: documentData, deviceKeyRaw: deviceKeyRaw)
+        
+        if document != nil {
+            XCTFail("document must not be valid")
+        }
+        
+    }
+    
+    
+    
+    
+}

--- a/IOWalletProximityExample/IOWalletProximityExample/View/QRCodeView.swift
+++ b/IOWalletProximityExample/IOWalletProximityExample/View/QRCodeView.swift
@@ -105,11 +105,17 @@ struct QRCodeView: View {
                     })
                     
                     
-                    guard let deviceResponse = Proximity.shared.generateDeviceResponse(allowed: allowed, items: items, documents: documents, sessionTranscript: nil) else {
-                        return
-                    }
+                    let deviceResponse = Proximity.shared.generateDeviceResponse(allowed: allowed, items: items, documents: documents, sessionTranscript: nil)
                     
-                    Proximity.shared.dataPresentation(allowed: allowed, deviceResponse)
+                    switch(deviceResponse) {
+                        case .success(let response):
+                            let dataPresentationResponse = Proximity.shared.dataPresentation(allowed: allowed, response)
+                            
+                            print(dataPresentationResponse)
+                        default:
+                            print(deviceResponse)
+                            return
+                    }
                 }
             }
             
@@ -162,9 +168,15 @@ struct QRCodeView: View {
         
         let trustedCertificates: [Data] = []
         
+        let startResult = Proximity.shared.start()
         
-        
-        qrCode = Proximity.shared.start() ?? ""
+        switch(startResult) {
+            case .success(let qrCode):
+                self.qrCode = qrCode
+                break
+            default:
+                qrCode = "";
+        }
     }
     
 }

--- a/IOWalletProximityExample/IOWalletProximityExample/View/QRCodeView.swift
+++ b/IOWalletProximityExample/IOWalletProximityExample/View/QRCodeView.swift
@@ -104,18 +104,16 @@ struct QRCodeView: View {
                         return nil
                     })
                     
-                    
-                    let deviceResponse = Proximity.shared.generateDeviceResponse(allowed: allowed, items: items, documents: documents, sessionTranscript: nil)
-                    
-                    switch(deviceResponse) {
-                        case .success(let response):
-                            let dataPresentationResponse = Proximity.shared.dataPresentation(allowed: allowed, response)
-                            
-                            print(dataPresentationResponse)
-                        default:
-                            print(deviceResponse)
-                            return
+                    do {
+                        let deviceResponse = try Proximity.shared.generateDeviceResponse(allowed: allowed, items: items, documents: documents, sessionTranscript: nil)
+                        
+                        let dataPresentationResponse = try Proximity.shared.dataPresentation(allowed: allowed, deviceResponse)
+                        
+                        print(dataPresentationResponse)
+                    } catch {
+                        print(error)
                     }
+                   
                 }
             }
             
@@ -168,14 +166,11 @@ struct QRCodeView: View {
         
         let trustedCertificates: [Data] = []
         
-        let startResult = Proximity.shared.start()
-        
-        switch(startResult) {
-            case .success(let qrCode):
-                self.qrCode = qrCode
-                break
-            default:
-                qrCode = "";
+        if let qrCode = try? Proximity.shared.start() {
+            self.qrCode = qrCode
+        }
+        else {
+            self.qrCode = ""
         }
     }
     

--- a/README.md
+++ b/README.md
@@ -25,13 +25,12 @@ public enum ProximityEvents {
 ```
 
 
-#### ProximityStatus
+#### ProximityError
 ```swift
 
-//  Possible response status of various methods
+//  Possible response errors of various methods
 
-public enum ProximityStatus<T> {
-    case success(result: T)
+public enum ProximityError {
     case nullObject(objectName: String)
     case decodingFailed(objectName: String)
     case error(error: Error)
@@ -44,7 +43,7 @@ public enum ProximityStatus<T> {
 //  Initialize the BLE manager, set the necessary listeners. Start the BLE and generate the QRCode string
 //  - Parameters:
 //      - trustedCertificates: list of trusted certificates to verify reader validity
-//  - Returns: ProximityStatus.success with string containing the DeviceEngagement data necessary to start the verification process as value
+//  - Returns: string containing the DeviceEngagement data necessary to start the verification process as value
 
 let qrCodeStatus = Proximity.shared.start()
 
@@ -94,14 +93,14 @@ public convenience init?(docType: String, issuerSigned: [UInt8], deviceKeyTag: S
  *   - documents: List of documents.
  *   - sessionTranscript: optional CBOR encoded session transcript
  *
- * - Returns: ProximityStatus.success with CBOR-encoded DeviceResponse object as value
+ * - Returns: CBOR-encoded DeviceResponse object as value
  */
 public func generateDeviceResponseFromJson(
     allowed: Bool,
     items: String?,
     documents: [ProximityDocument]?,
     sessionTranscript: [UInt8]?
-) -> ProximityStatus<[UInt8]> 
+) throws -> [UInt8]
 ```
 
 
@@ -116,14 +115,14 @@ public func generateDeviceResponseFromJson(
  *   - documents: List of documents.
  *   - sessionTranscript: optional CBOR encoded session transcript
  *
- * - Returns: ProximityStatus.success with CBOR-encoded DeviceResponse object as value
+ * - Returns: CBOR-encoded DeviceResponse object as value
  */
 public func generateDeviceResponse(
     allowed: Bool,
     items: [String: [String: [String: Bool]]]?,
     documents: [ProximityDocument]?,
     sessionTranscript: [UInt8]?
-) -> ProximityStatus<[UInt8]>
+) throws -> [UInt8]
 ```
 
 ```swift
@@ -169,7 +168,6 @@ switch(deviceResponseStatus) {
 //  - Parameters:
 //      - allowed: User has allowed the verification process
 //      - deviceResponse: Device Response cbor-encoded (result of Proximity.shared.generateDeviceResponse)
-//  - Returns: ProximityStatus
 
 let deviceResponse: [UInt8] = /*result of generateDeviceResponse*/
 


### PR DESCRIPTION
## Short description

Refactor error handling to have granular error handling

## List of changes proposed in this pull request

- Changed return value of exposed methods that could fail to ProximityStatus<T>
- Catch errors and return them as ProximityStatus.error

## How to test

```bash
bundle install
cd IOWalletProximityExample
bundler exec pod update
```

Open IOWalletProximityExample\IOWalletProximityExample.xcworkspace using Xcode.
