### PR TITLE
refactor: [IWP-115] DeviceRequest isAuthenticated on document level

### DIFF
--- a/IOWalletProximity/IOWalletProximity.xcodeproj/project.pbxproj
+++ b/IOWalletProximity/IOWalletProximity.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		3DA71A8A2D8C573700EC35EF /* SessionTranscriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DA71A892D8C573000EC35EF /* SessionTranscriptTests.swift */; };
 		3DC072092D7F3BA1003C35A2 /* iOS13HKDF.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DC072082D7F3BA1003C35A2 /* iOS13HKDF.swift */; };
 		3DCFB9C92D7894E7001050C3 /* Proximity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DCFB9C82D7894E4001050C3 /* Proximity.swift */; };
+		3DEB51BC2DC0B92000CC80BB /* DeviceRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DEB51BB2DC0B91B00CC80BB /* DeviceRequestTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -251,6 +252,7 @@
 		3DA71A892D8C573000EC35EF /* SessionTranscriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionTranscriptTests.swift; sourceTree = "<group>"; };
 		3DC072082D7F3BA1003C35A2 /* iOS13HKDF.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOS13HKDF.swift; sourceTree = "<group>"; };
 		3DCFB9C82D7894E4001050C3 /* Proximity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Proximity.swift; sourceTree = "<group>"; };
+		3DEB51BB2DC0B91B00CC80BB /* DeviceRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceRequestTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -406,6 +408,7 @@
 		3ADB28FB2CC2507A0087018A /* ModelTests */ = {
 			isa = PBXGroup;
 			children = (
+				3DEB51BB2DC0B91B00CC80BB /* DeviceRequestTests.swift */,
 				3DA71A892D8C573000EC35EF /* SessionTranscriptTests.swift */,
 				3ACBE9FF2CD28B1B00701457 /* DocumentErrorTests.swift */,
 				3ACBEA012CD2917700701457 /* ErrorsTests.swift */,
@@ -825,6 +828,7 @@
 				3ACBEA042CD2920F00701457 /* NameValueTests.swift in Sources */,
 				3ADB28FD2CC252CE0087018A /* ErrorHandlerTests.swift in Sources */,
 				3DA71A8A2D8C573700EC35EF /* SessionTranscriptTests.swift in Sources */,
+				3DEB51BC2DC0B92000CC80BB /* DeviceRequestTests.swift in Sources */,
 				3A652A2A2CAE9B3400B0D6E4 /* DrivingPrivilegesTests.swift in Sources */,
 				3A652A262CAE97C700B0D6E4 /* DeviceResponseTests.swift in Sources */,
 				3ACBE9FA2CD2898400701457 /* DictionaryExtensionsTests.swift in Sources */,

--- a/IOWalletProximity/IOWalletProximity/Document/Security/Cose/Cose.swift
+++ b/IOWalletProximity/IOWalletProximity/Document/Security/Cose/Cose.swift
@@ -282,10 +282,19 @@ extension Cose {
     /// - Returns: True if validation of signature succeeds
     public func validateDetachedCoseSign1(payloadData: Data, publicKey_x963: Data) throws -> Bool {
         let b: Bool
-        guard type == .sign1 else { /*logger.error("Cose must have type sign1");*/ return false}
-        guard let verifyAlgorithm = verifyAlgorithm else { /*logger.error("Cose signature algorithm not found");*/ return false}
+        guard type == .sign1 else {
+            //Cose must have type sign1
+            return false
+        }
+        guard let verifyAlgorithm = verifyAlgorithm else {
+            //Cose signature algorithm not found
+            return false
+        }
         let coseWithPayload = Cose(other: self, payloadData: payloadData)
-        guard let signatureStruct = coseWithPayload.signatureStruct else { /*logger.error("Cose signature struct cannot be computed");*/ return false}
+        guard let signatureStruct = coseWithPayload.signatureStruct else {
+            //Cose signature struct cannot be computed
+            return false
+        }
         switch verifyAlgorithm {
             case .es256:
                 let signingPubKey = try P256.Signing.PublicKey(x963Representation: publicKey_x963)
@@ -305,10 +314,19 @@ extension Cose {
     
     public func validateCoseSign1(publicKey_x963: Data) throws -> Bool {
         let b: Bool
-        guard type == .sign1 else { /*logger.error("Cose must have type sign1");*/ return false}
-        guard let verifyAlgorithm = verifyAlgorithm else { /*logger.error("Cose signature algorithm not found");*/ return false}
-        //let coseWithPayload = Cose(other: self, payloadData: payloadData)
-        guard let signatureStruct = self.signatureStruct else { /*logger.error("Cose signature struct cannot be computed");*/ return false}
+        guard type == .sign1 else {
+            //Cose must have type sign1
+            return false
+        }
+        guard let verifyAlgorithm = verifyAlgorithm else {
+            //Cose signature algorithm not found
+            return false
+        }
+        
+        guard let signatureStruct = self.signatureStruct else {
+            //Cose signature struct cannot be computed
+            return false
+        }
         switch verifyAlgorithm {
             case .es256:
                 let signingPubKey = try P256.Signing.PublicKey(x963Representation: publicKey_x963)

--- a/IOWalletProximity/IOWalletProximity/Proximity/BLE/MdocTransferHelpers.swift
+++ b/IOWalletProximity/IOWalletProximity/Proximity/BLE/MdocTransferHelpers.swift
@@ -24,11 +24,11 @@ class MdocTransferHelpers {
     public static func decodeRequest(deviceEngagement: DeviceEngagement?,  requestData: Data, dauthMethod: DeviceAuthMethod, readerKeyRawData: [UInt8]?, handOver: CBOR) -> Result<(sessionEncryption: SessionEncryption, deviceRequest: DeviceRequest), Error> {
         do {
             guard let seCbor = try CBOR.decode([UInt8](requestData)) else {
-                //logger.error("Request Data is not Cbor");
+                //Request Data is not Cbor
                 return .failure(ErrorHandler.requestDecodeError)
             }
             guard var se = SessionEstablishment(cbor: seCbor) else {
-                //logger.error("Request Data cannot be decoded to session establisment");
+                //Request Data cannot be decoded to session establisment
                 return .failure(ErrorHandler.requestDecodeError)
             }
             if se.eReaderKeyRawData == nil,
@@ -37,52 +37,45 @@ class MdocTransferHelpers {
             }
             
             guard se.eReaderKey != nil else {
-                //logger.error("Reader key not available");
+                //Reader key not available
                 return .failure(ErrorHandler.readerKeyMissing)
             }
             let requestCipherData = se.data
             guard let deviceEngagement else {
-                //logger.error("Device Engagement not initialized");
+                //Device Engagement not initialized
                 return .failure(ErrorHandler.deviceEngagementMissing)
             }
             // init session-encryption object from session establish message and device engagement, decrypt data
             let sessionEncryption = SessionEncryption(se: se, de: deviceEngagement, handOver: handOver)
             guard var sessionEncryption else {
-                //logger.error("Session Encryption not initialized");
+                //Session Encryption not initialized
                 return .failure(ErrorHandler.sessionEncryptionNotInitialized)
             }
-            guard let requestData = try sessionEncryption.decrypt(requestCipherData) else { //logger.error("Request data cannot be decrypted");
+            guard let requestData = try sessionEncryption.decrypt(requestCipherData) else {
+                //Request data cannot be decrypted
                 return .failure(ErrorHandler.requestDecodeError)
             }
             guard let deviceRequest = DeviceRequest(data: requestData) else {
-                //logger.error("Decrypted data cannot be decoded");
+                //Decrypted data cannot be decoded
                 return .failure(ErrorHandler.requestDecodeError)
             }
             
-            //var params: [String: Any] = [UserRequestKeys.valid_items_requested.rawValue: validRequestItems, UserRequestKeys.error_items_requested.rawValue: errorRequestItems]
-           
             return .success((sessionEncryption: sessionEncryption, deviceRequest: deviceRequest))
         } catch { return .failure(error) }
     }
     
     public static func isDeviceRequestDocumentValid(docR: DocRequest, iaca: [SecCertificate], sessionEncryption: SessionEncryption) -> Bool {
-        //if let docR = deviceRequest.docRequests.first {
-            let mdocAuth = MdocReaderAuthentication(transcript: sessionEncryption.transcript)
-            if let readerAuthRawCBOR = docR.readerAuthRawCBOR,
-               let certData = docR.readerCertificate,
-               let x509 = try? X509.Certificate(derEncoded: [UInt8](certData)),
-               let (isValidSignature, reasonFailure) = try? mdocAuth.validateReaderAuth(readerAuthCBOR: readerAuthRawCBOR, readerAuthCertificate: certData, itemsRequestRawData: docR.itemsRequestRawData!, rootCerts: iaca) {
-                //params[UserRequestKeys.reader_certificate_issuer.rawValue] = MdocHelpers.getCN(from: x509.subject.description)
-                //params[UserRequestKeys.reader_auth_validated.rawValue] = b
-                if let reasonFailure {
-                    //Certificate root authentication failed
-                    //params[UserRequestKeys.reader_certificate_validation_message.rawValue] = reasonFailure
-                    return false
-                    
-                }
-                return isValidSignature
+        let mdocAuth = MdocReaderAuthentication(transcript: sessionEncryption.transcript)
+        if let readerAuthRawCBOR = docR.readerAuthRawCBOR,
+           let certData = docR.readerCertificate,
+           let x509 = try? X509.Certificate(derEncoded: [UInt8](certData)),
+           let (isValidSignature, reasonFailure) = try? mdocAuth.validateReaderAuth(readerAuthCBOR: readerAuthRawCBOR, readerAuthCertificate: certData, itemsRequestRawData: docR.itemsRequestRawData!, rootCerts: iaca) {
+            if let reasonFailure {
+                //Certificate root authentication failed
+                return false
             }
-        //}
+            return isValidSignature
+        }
         return false
     }
     
@@ -94,11 +87,8 @@ class MdocTransferHelpers {
                let certData = docR.readerCertificate,
                let x509 = try? X509.Certificate(derEncoded: [UInt8](certData)),
                let (isValidSignature, reasonFailure) = try? mdocAuth.validateReaderAuth(readerAuthCBOR: readerAuthRawCBOR, readerAuthCertificate: certData, itemsRequestRawData: docR.itemsRequestRawData!, rootCerts: iaca) {
-                //params[UserRequestKeys.reader_certificate_issuer.rawValue] = MdocHelpers.getCN(from: x509.subject.description)
-                //params[UserRequestKeys.reader_auth_validated.rawValue] = b
                 if let reasonFailure {
                     //Certificate root authentication failed
-                    //params[UserRequestKeys.reader_certificate_validation_message.rawValue] = reasonFailure
                     return false
                     
                 }
@@ -146,7 +136,7 @@ class MdocTransferHelpers {
             // Document's data must be in CBOR bytes that has the IssuerSigned structure according to ISO 23220-4
             // Currently, the library does not support IssuerSigned structure without the nameSpaces field.
             guard let issuerNs = doc.issuerNameSpaces else {
-                //logger.error("Document does not contain issuer namespaces");
+                //Document does not contain issuer namespaces
                 return nil
             }
             var nsItemsToAdd = [String: [IssuerSignedItem]]()
@@ -193,7 +183,7 @@ class MdocTransferHelpers {
                     let authKeys = CoseKeyExchange(publicKey: eReaderKey, privateKey: devicePrivateKey)
                     let mdocAuth = MdocAuthentication(transcript: sessionTranscript, authKeys: authKeys)
                     guard let devAuth = try mdocAuth.getDeviceAuthForTransfer(docType: doc.issuerAuth!.mobileSecurityObject.docType, dauthMethod: dauthMethod) else {
-                        //logger.error("Cannot create device auth");
+                        //Cannot create device auth
                         return nil
                     }
                     devSignedToAdd = DeviceSigned(deviceAuth: devAuth)

--- a/IOWalletProximity/IOWalletProximity/Proximity/BLE/MdocTransferHelpers.swift
+++ b/IOWalletProximity/IOWalletProximity/Proximity/BLE/MdocTransferHelpers.swift
@@ -65,6 +65,28 @@ class MdocTransferHelpers {
         } catch { return .failure(error) }
     }
     
+    public static func isDeviceRequestDocumentValid(docR: DocRequest, iaca: [SecCertificate], sessionEncryption: SessionEncryption) -> Bool {
+        //if let docR = deviceRequest.docRequests.first {
+            let mdocAuth = MdocReaderAuthentication(transcript: sessionEncryption.transcript)
+            if let readerAuthRawCBOR = docR.readerAuthRawCBOR,
+               let certData = docR.readerCertificate,
+               let x509 = try? X509.Certificate(derEncoded: [UInt8](certData)),
+               let (isValidSignature, reasonFailure) = try? mdocAuth.validateReaderAuth(readerAuthCBOR: readerAuthRawCBOR, readerAuthCertificate: certData, itemsRequestRawData: docR.itemsRequestRawData!, rootCerts: iaca) {
+                //params[UserRequestKeys.reader_certificate_issuer.rawValue] = MdocHelpers.getCN(from: x509.subject.description)
+                //params[UserRequestKeys.reader_auth_validated.rawValue] = b
+                if let reasonFailure {
+                    //Certificate root authentication failed
+                    //params[UserRequestKeys.reader_certificate_validation_message.rawValue] = reasonFailure
+                    return false
+                    
+                }
+                return isValidSignature
+            }
+        //}
+        return false
+    }
+    
+    
     public static func isDeviceRequestValid(deviceRequest: DeviceRequest, iaca: [SecCertificate], sessionEncryption: SessionEncryption) -> Bool {
         if let docR = deviceRequest.docRequests.first {
             let mdocAuth = MdocReaderAuthentication(transcript: sessionEncryption.transcript)

--- a/IOWalletProximity/IOWalletProximity/Proximity/Helpers/MdocHelpers.swift
+++ b/IOWalletProximity/IOWalletProximity/Proximity/Helpers/MdocHelpers.swift
@@ -48,11 +48,11 @@ class MdocHelpers {
     static func decodeRequestAndInformUser(deviceEngagement: DeviceEngagement?, docs: [String: IssuerSigned], iaca: [SecCertificate], requestData: Data, devicePrivateKeys: [String: CoseKeyPrivate], dauthMethod: DeviceAuthMethod, readerKeyRawData: [UInt8]?, handOver: CBOR) -> Result<(sessionEncryption: SessionEncryption, deviceRequest: DeviceRequest, params: [String: Any], isValidRequest: Bool), Error> {
         do {
             guard let seCbor = try CBOR.decode([UInt8](requestData)) else {
-                //logger.error("Request Data is not Cbor");
+                //Request Data is not Cbor
                 return .failure(ErrorHandler.requestDecodeError)
             }
             guard var se = SessionEstablishment(cbor: seCbor) else {
-                //logger.error("Request Data cannot be decoded to session establisment");
+                //Request Data cannot be decoded to session establisment
                 return .failure(ErrorHandler.requestDecodeError)
             }
             if se.eReaderKeyRawData == nil,
@@ -61,29 +61,30 @@ class MdocHelpers {
             }
             
             guard se.eReaderKey != nil else {
-                //logger.error("Reader key not available");
+                //Reader key not available
                 return .failure(ErrorHandler.readerKeyMissing)
             }
             let requestCipherData = se.data
             guard let deviceEngagement else {
-                //logger.error("Device Engagement not initialized");
+                //Device Engagement not initialized
                 return .failure(ErrorHandler.deviceEngagementMissing)
             }
             // init session-encryption object from session establish message and device engagement, decrypt data
             let sessionEncryption = SessionEncryption(se: se, de: deviceEngagement, handOver: handOver)
             guard var sessionEncryption else {
-                //logger.error("Session Encryption not initialized");
+                //Session Encryption not initialized
                 return .failure(ErrorHandler.sessionEncryptionNotInitialized)
             }
-            guard let requestData = try sessionEncryption.decrypt(requestCipherData) else { //logger.error("Request data cannot be decrypted");
+            guard let requestData = try sessionEncryption.decrypt(requestCipherData) else {
+                //Request data cannot be decrypted
                 return .failure(ErrorHandler.requestDecodeError)
             }
             guard let deviceRequest = DeviceRequest(data: requestData) else {
-                //logger.error("Decrypted data cannot be decoded");
+                //Decrypted data cannot be decoded
                 return .failure(ErrorHandler.requestDecodeError)
             }
             guard let (drTest, validRequestItems, errorRequestItems) = try Self.getDeviceResponseToSend(deviceRequest: deviceRequest, issuerSigned: docs, selectedItems: nil, sessionEncryption: sessionEncryption, eReaderKey: sessionEncryption.sessionKeys.publicKey, devicePrivateKeys: devicePrivateKeys, dauthMethod: dauthMethod) else {
-                //logger.error("Valid request items nil");
+                //Valid request items nil
                 return .failure(ErrorHandler.requestDecodeError)
             }
             let bInvalidReq = (drTest.documents == nil)
@@ -143,7 +144,7 @@ class MdocHelpers {
             // Document's data must be in CBOR bytes that has the IssuerSigned structure according to ISO 23220-4
             // Currently, the library does not support IssuerSigned structure without the nameSpaces field.
             guard let issuerNs = doc.issuerNameSpaces else {
-                //logger.error("Document does not contain issuer namespaces");
+                //Document does not contain issuer namespaces
                 return nil
             }
             var nsItemsToAdd = [String: [IssuerSignedItem]]()
@@ -190,7 +191,7 @@ class MdocHelpers {
                     let authKeys = CoseKeyExchange(publicKey: eReaderKey, privateKey: devicePrivateKey)
                     let mdocAuth = MdocAuthentication(transcript: sessionTranscript, authKeys: authKeys)
                     guard let devAuth = try mdocAuth.getDeviceAuthForTransfer(docType: doc.issuerAuth!.mobileSecurityObject.docType, dauthMethod: dauthMethod) else {
-                        //logger.error("Cannot create device auth");
+                        //Cannot create device auth
                         return nil
                     }
                     devSignedToAdd = DeviceSigned(deviceAuth: devAuth)

--- a/IOWalletProximity/IOWalletProximity/Proximity/Security/SessionEncryption.swift
+++ b/IOWalletProximity/IOWalletProximity/Proximity/Security/SessionEncryption.swift
@@ -58,20 +58,20 @@ struct SessionEncryption {
         
         // Validate that the device engagement contains a private key
         guard let pk = de.privateKey else {
-            //logger.error("Device engagement for mdoc must have the private key");
+            //Device engagement for mdoc must have the private key
             return nil
         }
         
         // Validate that reader key raw data is available
         guard let rkrd = se.eReaderKeyRawData else {
-            //logger.error("Reader key data not available");
+            //Reader key data not available
             return nil
         }
         self.eReaderKeyRawData = rkrd
         
         // Validate that the eReader key can be decoded
         guard let ok = se.eReaderKey else {
-            //logger.error("Could not decode ereader key");
+            //Could not decode ereader key
             return nil
         }
         
@@ -192,7 +192,7 @@ struct SessionEncryption {
         
         // Perform ECKA-DH key agreement
         guard let sharedKey = sessionKeys.makeEckaDHAgreement(inSecureEnclave: sessionKeys.privateKey.secureEnclaveKeyID != nil) else {
-            //logger.error("Error in ECKA session key agreement");
+            //Error in ECKA session key agreement
             return nil
         }
         

--- a/IOWalletProximity/IOWalletProximityTests/LibIso18013DAOTests.swift
+++ b/IOWalletProximity/IOWalletProximityTests/LibIso18013DAOTests.swift
@@ -99,7 +99,8 @@ final class LibIso18013DAOTests: XCTestCase {
        let sessionTranscript = Proximity.shared.generateOID4VPSessionTranscriptCBOR(clientId: "clientId", responseUri: "responseUri", authorizationRequestNonce: "authorizationRequestNonce", mdocGeneratedNonce: "mdocNonce")
         
         
-        guard case .success(let deviceResponseRaw) = Proximity.shared.generateDeviceResponse(allowed: true, items: items, documents: documents, sessionTranscript: sessionTranscript) else {
+        
+        guard let deviceResponseRaw = try? Proximity.shared.generateDeviceResponse(allowed: true, items: items, documents: documents, sessionTranscript: sessionTranscript) else {
             XCTFail("deviceResponse must be valid")
             return
         }

--- a/IOWalletProximity/IOWalletProximityTests/ModelTests/DeviceRequestTests.swift
+++ b/IOWalletProximity/IOWalletProximityTests/ModelTests/DeviceRequestTests.swift
@@ -1,0 +1,30 @@
+//
+//  DeviceRequestTests.swift
+//  IOWalletProximity
+//
+//  Created by Antonio Caparello on 29/04/25.
+//
+
+import XCTest
+import Security
+internal import SwiftCBOR
+
+@testable import IOWalletProximity
+
+class DeviceRequestTests: XCTestCase {
+    func testDeviceRequestToJson() {
+        
+        guard let deviceRequest = DeviceRequest(data: AnnexdTestData.d411.bytes) else {
+            XCTFail("failed to decode deviceRequest")
+            return
+        }
+        
+        let json = Proximity().buildDeviceRequestJson(item: deviceRequest)
+        
+        json.forEach({
+            docRequest in
+            //isAuthenticated must be false as we are not initializing the sessiontranscript nor passing IACA certificates
+            XCTAssert(!docRequest.isAuthenticated)
+        })
+    }
+}

--- a/IOWalletProximityExample/IOWalletProximityExample/View/QRCodeView.swift
+++ b/IOWalletProximityExample/IOWalletProximityExample/View/QRCodeView.swift
@@ -73,7 +73,7 @@ struct QRCodeView: View {
                 let req:  [String: [String: [String]]] = {
                     var popupRequest : [String: [String: [String]]] = [:]
                     
-                     request?.request?.forEach({
+                     request?.forEach({
                         item in
                          
                          var subReq: [String: [String]] = [:]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The library offers a specific set of functions to handle BLE proximity as specif
 public enum ProximityEvents {
     case onBleStart
     case onBleStop
-    case onDocumentRequestReceived(request:  (request: [(docType: String, nameSpaces: [String: [String: Bool]])]?, isAuthenticated: Bool)?)
+    case onDocumentRequestReceived(request: [(docType: String, nameSpaces: [String: [String: Bool]], isAuthenticated: Bool)]?)
     case onDocumentPresentationCompleted
     case onError(error: Error)
     case onLoading


### PR DESCRIPTION
## DeviceRequest isAuthenticated on document level

Align isAuthenticated value to Android. For each requested document there is a "isAuthenticated" value

```json
{
  "request": {
    "org.iso.18013.5.1.mDL": {
      "org.iso.18013.5.1": {
        "portrait": false,
        "birth_date": false,
        "given_name": false,
        "issue_date": false,
        "expiry_date": false,
        "family_name": false,
        "document_number": false,
        "issuing_country": false,
        "issuing_authority": false,
        "driving_privileges": false,
        "un_distinguishing_sign": false
      },
      "isAuthenticated": true
    }
  }
}
```

## How to test

Test a presentation flow with the verifier app and print the request returned. Check if each document requested has a isAuthenticated boolean attribute.

A test has been added in 'DeviceRequestTests.swift' to check if the parameter is present in a decoded DeviceRequest

```bash
bundle install
cd IOWalletProximityExample
bundler exec pod update
```

Open IOWalletProximityExample\IOWalletProximityExample.xcworkspace using Xcode.
