### PR TITLE
fix: [IWP-121] Fix encodedClientId and encodedResponseUri encoding for OID4VP

### DIFF
--- a/IOWalletProximity/IOWalletProximity/OID4VP/OID4VPHandover.swift
+++ b/IOWalletProximity/IOWalletProximity/OID4VP/OID4VPHandover.swift
@@ -15,15 +15,15 @@ struct OID4VPHandover : CBOREncodable {
     let mdocGeneratedNonce: String
     
     func toCBOR(options: SwiftCBOR.CBOROptions) -> SwiftCBOR.CBOR {
-        let encodedClientId = CBOR(arrayLiteral: [
+        let encodedClientId = CBOR(arrayLiteral:
             .utf8String(clientId),
             .utf8String(mdocGeneratedNonce)
-        ]).encode()
+        ).encode()
         
-        let encodedResponseUri = CBOR(arrayLiteral: [
+        let encodedResponseUri = CBOR(arrayLiteral:
             .utf8String(responseUri),
             .utf8String(mdocGeneratedNonce)
-        ]).encode()
+        ).encode()
         
         let clientIdChecksum = calcSHA256Hash(encodedClientId)
         let responseUriChecksum = calcSHA256Hash(encodedResponseUri)

--- a/IOWalletProximity/IOWalletProximityTests/ModelTests/SessionTranscriptTests.swift
+++ b/IOWalletProximity/IOWalletProximityTests/ModelTests/SessionTranscriptTests.swift
@@ -18,7 +18,7 @@ class SessionTranscriptTests: XCTestCase {
         let authorizationRequestNonce = "AUTH NONCE"
         let mdocNonce = "MDOC NONCE"
         
-        let generatedOid4vpSessionTranscript = "g/b2g1ggxUpjPEK7GoBmVsdwEzkQzlL9Kjd16xaMk4qmS5XhMlFYIPQlZ089PEspsVYm/PjJRfWZ5wLXMFiD8onG/RgRbhPLakFVVEggTk9OQ0U="
+        let generatedOid4vpSessionTranscript = "g/b2g1gghjCGDo4W3FVIjOeOe5C71ZEiI1XyJOXon2VoA2s7TexYIMKUSNBIvZ/iE9JHfBT1RFa8XdQJDiqkuxFKWdPTiLGmakFVVEggTk9OQ0U="
         
         let oid4vpSessionTranscript = Proximity().generateOID4VPSessionTranscriptCBOR(
             clientId: clientId,


### PR DESCRIPTION
## Short description

Fixed encoding of OID4VP handover data before hash. 

## How to test

Test by generating OID4VP SessionTranscript and verify if result is what is expected.
