### PR TITLE
refactor: [IWP-123] ProximityEvents alignment

### DIFF
--- a/IOWalletProximityExample/IOWalletProximityExample/View/QRCodeView.swift
+++ b/IOWalletProximityExample/IOWalletProximityExample/View/QRCodeView.swift
@@ -26,7 +26,27 @@ struct QRCodeView: View {
     
     @State var loading: Bool = false
     
+    func logEvent() -> String {
+        switch(proximityEvent) {
+            case .onDocumentPresentationCompleted:
+                return "onDocumentPresentationCompleted"
+            case .onDeviceConnecting:
+                return "onDeviceConnecting"
+            case .onDeviceConnected:
+                return "onDeviceConnected"
+            case .onDocumentRequestReceived( _):
+                return "onDocumentRequestReceived"
+            case .onDeviceDisconnected:
+                return "onDeviceDisconnected"
+            case .onError( _):
+                return "onError"
+        }
+    }
+    
     func viewForEvent() -> AnyView {
+        //PRINT LOG TO CHECK IF EVENTS ARE CORRECT
+        print(logEvent())
+        
         switch(proximityEvent) {
             case .onError(let error):
                 if let proximityError = error as? ErrorHandler,

--- a/README.md
+++ b/README.md
@@ -44,16 +44,11 @@ pod install
 import IOWalletProximity
 
 // Start the proximity service
-let qrCodeStatus = Proximity.shared.start()
+try Proximity.shared.start()
 
-switch(qrCodeStatus) {
-    case .success(let qrCode):
-        //use qrCode
-        print(qrCode)
-    default:
-        print(qrCodeStatus)
-        //start failed for some reasons
-}
+let qrCode = try Proximity.shared.getQrCode()
+
+print(qrCode)
 
 //  Stops the BLE manager and closes connections.
 Proximity.shared.stop()
@@ -62,18 +57,33 @@ Proximity.shared.stop()
 // Listen for proximity events
 Proximity.shared.proximityHandler = { event in
     switch event {
-    case .onBleStart:
-        // BLE service started
-    case .onDocumentRequestReceived(let request):
-        // Handle document request
-    case .onDocumentPresentationCompleted:
-        // Document successfully presented
-    case .onError(let error):
-        // Handle error
-    case .onLoading:
-        // Loading state
-    case .onBleStop:
-        // BLE service stopped
+        //The device is done sending documents
+        case onDocumentPresentationCompleted:
+        break
+    
+        //The device is connecting to the verifier app
+        case onDeviceConnecting:
+        break
+    
+        //The device has connected to the verifier app
+        case onDeviceConnected:
+        break
+    
+        //The device has received a new request from the verifier app
+        case onDocumentRequestReceived(request: [
+            (docType: String,
+            nameSpaces: [String: [String: Bool]],
+            isAuthenticated: Bool)
+        ]?):
+        break
+    
+        //The device has received the termination flag from the verifier app
+        case onDeviceDisconnected:
+        break
+    
+        //An error occurred
+        case onError(error: Error):
+        break
     }
 }
 ```
@@ -99,13 +109,30 @@ public convenience init?(docType: String, issuerSigned: [UInt8], deviceKeyTag: S
 ```swift
 //  In order to listen for proximity events set this handler
 
+
 public enum ProximityEvents {
-    case onBleStart
-    case onBleStop
-    case onDocumentRequestReceived(request: [(docType: String, nameSpaces: [String: [String: Bool]], isAuthenticated: Bool)]?)
+    //The device is done sending documents
     case onDocumentPresentationCompleted
+    
+    //The device is connecting to the verifier app
+    case onDeviceConnecting
+    
+    //The device has connected to the verifier app
+    case onDeviceConnected
+    
+    //The device has received a new request from the verifier app
+    case onDocumentRequestReceived(request: [
+        (docType: String,
+         nameSpaces: [String: [String: Bool]],
+         isAuthenticated: Bool)
+    ]?)
+    
+    //The device has received the termination flag from the verifier app
+    case onDeviceDisconnected
+    
+    //An error occurred
     case onError(error: Error)
-    case onLoading
+    
 }
 
  Proximity.shared.proximityHandler = {


### PR DESCRIPTION
## ProximityEvents alignment

- ProximityEvents has been changed to:

```swift
public enum ProximityEvents {
    //The device is done sending documents
    case onDocumentPresentationCompleted
    
    //The device is connecting to the verifier app
    case onDeviceConnecting
    
    //The device has connected to the verifier app
    case onDeviceConnected
    
    //The device has received a new request from the verifier app
    case onDocumentRequestReceived(request: [
        (docType: String,
         nameSpaces: [String: [String: Bool]],
         isAuthenticated: Bool)
    ]?)
    
    //The device has received the termination flag from the verifier app
    case onDeviceDisconnected
    
    //An error occurred
    case onError(error: Error)
    
}
```

- The `Proximity.shared.start()` method is now responsible only of initialization details.

- QrCode generation has been decoupled from the `Proximity.shared.start()` method and now resides in the `Proximity.shared.getQrCode()` method

## How to test

```bash
bundle install
cd IOWalletProximityExample
bundler exec pod update
```

Open IOWalletProximityExample\IOWalletProximityExample.xcworkspace using Xcode.

Perform proximity authentication and check if events are fired correctly. Also check if `Proximity.shared.getQrCode()` returns a valid DeviceEngagement value.
