### PR TITLE
refactor: [IWP-127] dataPresentation and errorPresentation

### DIFF
--- a/IOWalletProximity/IOWalletProximity/Proximity/Helpers/MdocHelpers.swift
+++ b/IOWalletProximity/IOWalletProximity/Proximity/Helpers/MdocHelpers.swift
@@ -19,7 +19,7 @@ class MdocHelpers {
     static var errorNoDocumentsDescriptionKey: String { "doctype_not_found" }
     static func getErrorNoDocuments(_ docType: String) -> Error { NSError(domain: "\(MdocBleServer.self)", code: 0, userInfo: ["key": Self.errorNoDocumentsDescriptionKey, "%s": docType]) }
  
-    public static func getSessionDataToSend(sessionEncryption: SessionEncryption?, status: TransferStatus, docToSend: DeviceResponse) -> Result<Data, Error> {
+    public static func getSessionDataToSend(sessionEncryption: SessionEncryption?, status: TransferStatus, docToSend: DeviceResponse, errorStatus: UInt64 = 11) -> Result<Data, Error> {
         do {
             guard var sessionEncryption else {
                 return .failure(ErrorHandler.sessionEncryptionNotInitialized)
@@ -30,7 +30,7 @@ class MdocHelpers {
             let cborToSend = docToSend.toCBOR(options: CBOROptions())
             let clearBytesToSend = cborToSend.encode()
             let cipherData = try sessionEncryption.encrypt(clearBytesToSend)
-            let sd = SessionData(cipher_data: status == .error ? nil : cipherData, status: status == .error ? 11 : 20)
+            let sd = SessionData(cipher_data: status == .error ? nil : cipherData, status: status == .error ? errorStatus : 20)
             return .success(Data(sd.encode(options: CBOROptions())))
         } catch { return .failure(error) }
     }

--- a/IOWalletProximity/IOWalletProximity/Proximity/LibIso18013Proximity.swift
+++ b/IOWalletProximity/IOWalletProximity/Proximity/LibIso18013Proximity.swift
@@ -10,7 +10,7 @@ protocol QrEngagementListener: AnyObject {
     // Called when the connection process is starting
     func didChangeStatus(_ newStatus: TransferStatus)
     
-    func didReceiveRequest(deviceRequest: DeviceRequest, sessionEncryption: SessionEncryption, onResponse: @escaping (Bool, DeviceResponse?) -> Void)
+    func didReceiveRequest(deviceRequest: DeviceRequest, sessionEncryption: SessionEncryption, onResponse: @escaping (Bool, DeviceResponse?, UInt64) -> Void)
     
     func didFinishedWithError(_ error: any Error)
     
@@ -92,7 +92,7 @@ class LibIso18013Proximity: @unchecked Sendable {
             listener.didFinishedWithError(error)
         }
         
-        func didReceiveRequest(deviceRequest: DeviceRequest, sessionEncryption: SessionEncryption, onResponse: @escaping (Bool, DeviceResponse?) -> Void) {
+        func didReceiveRequest(deviceRequest: DeviceRequest, sessionEncryption: SessionEncryption, onResponse: @escaping (Bool, DeviceResponse?, UInt64) -> Void) {
             listener.didReceiveRequest(deviceRequest: deviceRequest, sessionEncryption: sessionEncryption, onResponse: onResponse)
         }
     }

--- a/IOWalletProximity/IOWalletProximityTests/LibIso18013DAOTests.swift
+++ b/IOWalletProximity/IOWalletProximityTests/LibIso18013DAOTests.swift
@@ -100,7 +100,7 @@ final class LibIso18013DAOTests: XCTestCase {
         
         
         
-        guard let deviceResponseRaw = try? Proximity.shared.generateDeviceResponse(allowed: true, items: items, documents: documents, sessionTranscript: sessionTranscript) else {
+        guard let deviceResponseRaw = try? Proximity.shared.generateDeviceResponse(items: items, documents: documents, sessionTranscript: sessionTranscript) else {
             XCTFail("deviceResponse must be valid")
             return
         }

--- a/IOWalletProximity/IOWalletProximityTests/LibIso18013ProximityTests.swift
+++ b/IOWalletProximity/IOWalletProximityTests/LibIso18013ProximityTests.swift
@@ -36,7 +36,7 @@ class MockQrEngagementListener: QrEngagementListener {
         
     }
     
-    func didReceiveRequest(deviceRequest: IOWalletProximity.DeviceRequest, sessionEncryption: IOWalletProximity.SessionEncryption, onResponse: @escaping (Bool, IOWalletProximity.DeviceResponse?) -> Void) {
+    func didReceiveRequest(deviceRequest: IOWalletProximity.DeviceRequest, sessionEncryption: IOWalletProximity.SessionEncryption, onResponse: @escaping (Bool, IOWalletProximity.DeviceResponse?, UInt64) -> Void) {
         
     }
     

--- a/IOWalletProximityExample/IOWalletProximityExample/View/QRCodeView.swift
+++ b/IOWalletProximityExample/IOWalletProximityExample/View/QRCodeView.swift
@@ -131,9 +131,15 @@ struct QRCodeView: View {
                     })
                     
                     do {
-                        let deviceResponse = try Proximity.shared.generateDeviceResponse(allowed: allowed, items: items, documents: documents, sessionTranscript: nil)
+                        if (allowed) {
+                            let deviceResponse = try Proximity.shared.generateDeviceResponse(items: items, documents: documents, sessionTranscript: nil)
+                            
+                            try Proximity.shared.dataPresentation( deviceResponse)
+                        }
+                        else {
+                            try Proximity.shared.errorPresentation(.errorCborDecoding)
+                        }
                         
-                        try Proximity.shared.dataPresentation(allowed: allowed, deviceResponse)
                         
                     } catch {
                         print(error)


### PR DESCRIPTION
`dataPresentation` now accepts only device response and error is sent by `errorPresentation`

## List of changes proposed in this pull request

- Changed signature of dataPresentation removing the "allowed" parameter
- Added errorPresentation to handle SessionDataStatus to be sent to the verifier app
- Added SessionDataStatus enum mirroring table 20 of ISO18013 spec

## How to test

```bash
bundle install
cd IOWalletProximityExample
bundler exec pod update
```

Open IOWalletProximityExample\IOWalletProximityExample.xcworkspace using Xcode.

- Perform proximity authentication and accept request in the popup to test  `dataPresentation`
- Perform proximity authentication and decline request in the popup to test `errorPresentation`
