### PR TITLE
refactor: [IWP-129] Don't trigger onError when the error has been sent by 'errorPresentation'

### DIFF
--- a/IOWalletProximity/IOWalletProximity/Proximity/BLE/MdocBleServer.swift
+++ b/IOWalletProximity/IOWalletProximity/Proximity/BLE/MdocBleServer.swift
@@ -166,7 +166,7 @@ class MdocBleServer : @unchecked Sendable {
         status = .userSelected
         
         if !userApproved {
-            sendError(ErrorHandler.userRejected, errorStatus: errorStatus)
+            sendError(nil, errorStatus: errorStatus)
             return
         }
         


### PR DESCRIPTION


## Don't trigger onError when the error has been sent by 'errorPresentation'

## How to test

Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

```bash
bundle install
cd IOWalletProximityExample
bundler exec pod update
```

Open IOWalletProximityExample\IOWalletProximityExample.xcworkspace using Xcode.

Perform proximity authentication and decline request in the popup to test errorPresentation. Then check that onError event is not fired.
