### PR TITLE
feat: [IWP-129] onError when the verifier app disconnects without sending proper termination flag

### DIFF
--- a/IOWalletProximity/IOWalletProximity/Proximity.swift
+++ b/IOWalletProximity/IOWalletProximity/Proximity.swift
@@ -11,6 +11,7 @@ public enum ProximityError : Error, CustomStringConvertible {
     case nullObject(objectName: String)
     case decodingFailed(objectName: String)
     case error(error: Error)
+    case disconnectedWithoutProperSessionTermination
     
     public var description: String {
         switch(self) {
@@ -22,6 +23,9 @@ public enum ProximityError : Error, CustomStringConvertible {
                 
             case .error(let error):
                 return error.localizedDescription
+            
+            case .disconnectedWithoutProperSessionTermination:
+                return "Disconnected without proper Session Termination (END_REQUEST)"
         }
     }
 }

--- a/IOWalletProximity/IOWalletProximity/Proximity/BLE/MdocBleServer.swift
+++ b/IOWalletProximity/IOWalletProximity/Proximity/BLE/MdocBleServer.swift
@@ -304,5 +304,13 @@ class MdocBleDelegate : NSObject, CBPeripheralManagerDelegate {
     public func peripheralManager(_ peripheral: CBPeripheralManager, central: CBCentral, didUnsubscribeFrom characteristic: CBCharacteristic) {
         let mdocCbc = MdocServiceCharacteristic(uuid: characteristic.uuid)
         print("Remote central \(central.identifier) disconnected for \(mdocCbc?.rawValue ?? "") characteristic")
+        
+        if (server.status != .disconnected)  {
+            if (server.status == .error) {
+                return
+            }
+            
+            server.error = ProximityError.disconnectedWithoutProperSessionTermination
+        }
     }
 }

--- a/IOWalletProximityExample/IOWalletProximityExample/View/QRCodeView.swift
+++ b/IOWalletProximityExample/IOWalletProximityExample/View/QRCodeView.swift
@@ -83,8 +83,8 @@ struct QRCodeView: View {
                         HStack {
                             Text("Error")
                                 .font(.title)
-                                .foregroundStyle(.green)
-                            Image(systemName: "checkmark")
+                                .foregroundStyle(.red)
+                            Image(systemName: "multiply")
                                 .resizable()
                                 .frame(width: 24, height: 24)
                                 .foregroundStyle(.red)
@@ -237,6 +237,9 @@ struct QRCodeView: View {
                         if case .onError(let error) = proximityEvent {
                             if let proximityError = error as? ErrorHandler {
                                 return proximityError.localizedDescription
+                            }
+                            if let proximityError = error as? ProximityError {
+                                return proximityError.description
                             }
                             return error.localizedDescription
                         } else {


### PR DESCRIPTION

## List of changes proposed in this pull request

- onError event (`ProximityError.disconnectedWithoutProperSessionTermination`) when the verifier app disconnects without sending proper termination flag

## How to test

```bash
bundle install
cd IOWalletProximityExample
bundler exec pod update
```

Open IOWalletProximityExample\IOWalletProximityExample.xcworkspace using Xcode.

Perform proximity authentication and accept request in the popup using Android Verifier App. Then check that onError event was fired.
