### PR TITLE
refactor: [SIW-000] Remove NFC cooldown logic and related documentation from ISO18013 implementation

### DIFF
--- a/IOWalletProximity/IOWalletProximity/ISO18013.swift
+++ b/IOWalletProximity/IOWalletProximity/ISO18013.swift
@@ -67,16 +67,6 @@ public protocol ISO18013Delegate {
 
 public class ISO18013 : @unchecked Sendable {
     
-    //The intent assertion expires if any of the following occur:
-    //The intent assertion object deinitializes -> occurs when ISO18013.shared.stopNfc() is called
-    //15 seconds elapse after the intent assertion initialized
-    public static let nfcHLESessionTimeRemaining: TimeInterval = 15
-    
-    //After the intent assertion expires, your app will need to wait 15 seconds before acquiring a new intent assertion.
-    public static let nfcHLESessionCoolDownTimeRemaining: TimeInterval = 15
-    
-    
-    
     public static let shared: ISO18013 = ISO18013()
     
     private var isNfcLateEngagement: Bool = false
@@ -152,7 +142,7 @@ public class ISO18013 : @unchecked Sendable {
                 throw ProximityError.nfcFailedToStart
             }
         }
-            _initializeNfcEngagement(isLate: true)
+            _initializeNfcEngagement(isLate: false)
         
     }
     
@@ -302,33 +292,6 @@ public class ISO18013 : @unchecked Sendable {
         }
         
         Task {
-            let nfcStartTime = self.nfcStartTime
-            let nfcCoolDownTime = self.nfcCoolDownTime
-            if let nfcStartTime {
-                //nfc started
-                if let nfcCoolDownTime {
-                    //nfc stopped
-                    if nfcCoolDownTime.distance(to: Date()) > ISO18013.nfcHLESessionCoolDownTimeRemaining {
-                        //ok can reset
-                        self.nfcStartTime = nil
-                        self.nfcCoolDownTime = nil
-                    }
-                    else {
-                        triggerEvent(.error(ProximityError.nfcCooldownNotExpired))
-                        return;
-                    }
-                }
-                else {
-                    if nfcStartTime.distance(to: Date()) > ISO18013.nfcHLESessionTimeRemaining {
-                        //ok can reset
-                        self.nfcStartTime = nil
-                    }
-                    else {
-                        triggerEvent(.error(ProximityError.nfcAlreadyStarted))
-                        return
-                    }
-                }
-            }
             do {
                 
                 var nfcEngagement = false
@@ -344,7 +307,7 @@ public class ISO18013 : @unchecked Sendable {
                     }
                 }
                 
-                if (!nfcEngagement && !isLate) {
+                if (!nfcEngagement && isLate) {
                     print("no nfc engagement")
                     return
                 }

--- a/IOWalletProximity/IOWalletProximity/ISO18013.swift
+++ b/IOWalletProximity/IOWalletProximity/ISO18013.swift
@@ -74,8 +74,6 @@ public class ISO18013 : @unchecked Sendable {
     private var retrivalMethods: [ISO18013DataTransferMode] = []
     private var delegate: ISO18013Delegate?
     
-    private var nfcStartTime: Date?
-    private var nfcCoolDownTime: Date?
     private var nfcDataTransfer: Bool = false
     private var nfcEngagement: Bool = false
     
@@ -205,13 +203,11 @@ public class ISO18013 : @unchecked Sendable {
     private func handleNfcEvent(_ event: ProximityNfcEvents) {
         switch(event) {
         case .onStart:
-            nfcStartTime = Date()
             triggerEvent(.nfcStarted)
             nfcDataTransfer = false
             nfcEngagement = false
             break
         case .onStop:
-            nfcCoolDownTime = Date()
             triggerEvent(.nfcStopped)
             nfcDataTransfer = false
             nfcEngagement = false

--- a/IOWalletProximity/IOWalletProximity/Proximity.swift
+++ b/IOWalletProximity/IOWalletProximity/Proximity.swift
@@ -12,9 +12,7 @@ public enum ProximityError : Error, CustomStringConvertible {
     case decodingFailed(objectName: String)
     case error(error: Error)
     case disconnectedWithoutProperSessionTermination
-    case nfcCooldownNotExpired
     case nfcNotSupported
-    case nfcAlreadyStarted
     case nfcFailedToStart
     case nfcEngagementWihtEngagementDisabled
     
@@ -31,11 +29,6 @@ public enum ProximityError : Error, CustomStringConvertible {
             
             case .disconnectedWithoutProperSessionTermination:
                 return "Disconnected without proper Session Termination (END_REQUEST)"
-        
-        case .nfcCooldownNotExpired:
-            return "NFC HCE Cooldown not expired"
-        case .nfcAlreadyStarted:
-            return "NFC HCE Already started"
         case .nfcFailedToStart:
             return "NFC HCE Failed to start"
         case .nfcNotSupported:

--- a/IOWalletProximity/IOWalletProximity/Proximity/LibIso18013Proximity.swift
+++ b/IOWalletProximity/IOWalletProximity/Proximity/LibIso18013Proximity.swift
@@ -210,14 +210,11 @@ class LibIso18013Proximity: @unchecked Sendable {
         
         print("startRetrivalMethods allowEngagement: \(allowEngagement) isLate: \(isNfcLateEngagement)")
         
-        var isFirstTime = true
-        
         if retrivalMethodsStarted {
-            isFirstTime = false
             print("retrivalMethods already started")
             
-            if !isNfcLateEngagement {
-                print("retrivalMethods already started and !isNfcLateEngagement")
+            if isNfcLateEngagement {
+                print("retrivalMethods already started and isNfcLateEngagement")
                 return
             }
             
@@ -235,7 +232,8 @@ class LibIso18013Proximity: @unchecked Sendable {
                     try? initBleServer()
                     break
                 case .nfc:
-                    if !isNfcLateEngagement || !isFirstTime || (isNfcLateEngagement && isFirstTime){
+                    print("isNfcLateEngagement: \(isNfcLateEngagement)")
+                    if !isNfcLateEngagement {
                         if #available(iOS 17.4, *) {
                             Task {
                                 try await startNfcDataTransfer(allowEngagement)

--- a/IOWalletProximity/IOWalletProximity/Proximity/NFC/NFCCardEmulator.swift
+++ b/IOWalletProximity/IOWalletProximity/Proximity/NFC/NFCCardEmulator.swift
@@ -82,18 +82,28 @@ class NFCCardEmulator : @unchecked Sendable {
         
         let cardSession: CardSession
         
-            do {
-                presentmentIntent = try await NFCPresentmentIntentAssertion.acquire()
-            } catch {
-                print("NFCPresentmentIntentAssertion.acquire() error: \(error)")
-                /// Handle failure to acquire NFC presentment intent assertion or
-                /// card session.
-                return false
-            }
+        var intent: Bool = false
+        
+//            do {
+//                presentmentIntent = try await NFCPresentmentIntentAssertion.acquire()
+//                intent = true
+//            } catch {
+//                print("NFCPresentmentIntentAssertion.acquire() error: \(error)")
+//                
+//                
+//                
+//                /// Handle failure to acquire NFC presentment intent assertion or
+//                /// card session.
+//                //return false
+//            }
         
         
         do {
             cardSession = try await CardSession()
+            
+            if !intent {
+                try await cardSession.startEmulation()
+            }
             
         } catch {
             print("CardSession() error: \(error)")
@@ -105,7 +115,10 @@ class NFCCardEmulator : @unchecked Sendable {
         self.cardSession = cardSession
         self.presentmentIntent = presentmentIntent
         
+        
+        
         Task {
+            
             // Iterate over events as the card session produces them.
             for try await event in cardSession.eventStream {
                 delegate.emulationStatusChanged(event)

--- a/IOWalletProximity/IOWalletProximity/Proximity/NFC/NFCCardEmulator.swift
+++ b/IOWalletProximity/IOWalletProximity/Proximity/NFC/NFCCardEmulator.swift
@@ -82,28 +82,10 @@ class NFCCardEmulator : @unchecked Sendable {
         
         let cardSession: CardSession
         
-        var intent: Bool = false
-        
-//            do {
-//                presentmentIntent = try await NFCPresentmentIntentAssertion.acquire()
-//                intent = true
-//            } catch {
-//                print("NFCPresentmentIntentAssertion.acquire() error: \(error)")
-//                
-//                
-//                
-//                /// Handle failure to acquire NFC presentment intent assertion or
-//                /// card session.
-//                //return false
-//            }
-        
-        
         do {
             cardSession = try await CardSession()
             
-            if !intent {
-                try await cardSession.startEmulation()
-            }
+            try await cardSession.startEmulation()
             
         } catch {
             print("CardSession() error: \(error)")

--- a/IOWalletProximityExample/IOWalletProximityExample/View/ISO18013View.swift
+++ b/IOWalletProximityExample/IOWalletProximityExample/View/ISO18013View.swift
@@ -29,9 +29,6 @@ struct ISO18013View: View {
     @State var bleConnecting = false
     @State var bleConnected = false
     
-    let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
-    @State private var timeRemaining = 0
-    
     func _retrivalMethods() -> [ISO18013DataTransferMode] {
         var result: [ISO18013DataTransferMode] = []
         
@@ -73,21 +70,6 @@ struct ISO18013View: View {
         }
     }
     
-    func _nfcTimerView() -> some View {
-        VStack {
-            if (timeRemaining > 0) {
-                
-                Text("\(nfc ? "Session" : "Cooldown") remaining time:\n \(timeRemaining)")
-                    .font(.largeTitle)
-                    .foregroundStyle(.white)
-                    .padding(.horizontal, 20)
-                    .padding(.vertical, 5)
-                    .background(.black.opacity(0.75))
-                    .clipShape(.capsule)
-                    .multilineTextAlignment(.center)
-            }
-        }
-    }
     
     func _configView() -> some View {
         return VStack {
@@ -207,16 +189,8 @@ struct ISO18013View: View {
             })
             .buttonStyle(.borderedProminent)
             .tint(Color.green)
-            .disabled(_nfcCanNotPerformActions)
-            if !nfcEngagementLate {
-                _nfcTimerView()
-            }
         }.padding(.horizontal, 16)
             .padding(.vertical, 16)
-    }
-    
-    var _nfcCanNotPerformActions: Bool {
-        return (nfcEngagement || nfcDataTransfer) ? timeRemaining > 0 : false
     }
     
     func _backToSettings() {
@@ -254,11 +228,6 @@ struct ISO18013View: View {
                         .frame(width: 100, height: 100)
                 }) .buttonStyle(.borderedProminent)
                     .tint(Color.green)
-                    .disabled(_nfcCanNotPerformActions)
-            }
-            
-            if nfcEngagement || nfcDataTransfer {
-                _nfcTimerView()
             }
             
             Button(action: {
@@ -331,17 +300,6 @@ struct ISO18013View: View {
                     
                 }
             }
-        }
-        .onReceive(timer) {
-            time in
-            if timeRemaining > 0 {
-                timeRemaining -= 1
-                if (nfc && timeRemaining == 0) {
-                    ISO18013.shared.stop()
-                }
-            }
-            
-            
         }
         .sheet(isPresented: .init(get: {
             return dataTransferArgs != nil
@@ -426,11 +384,9 @@ extension ISO18013View : ISO18013Delegate {
             break
         case .nfcStarted:
             self.nfc = true
-            self.timeRemaining = Int(ISO18013.nfcHLESessionTimeRemaining)
             break
         case .nfcStopped:
             self.nfc = false
-            self.timeRemaining = Int(ISO18013.nfcHLESessionCoolDownTimeRemaining)
             break
         case .dataTransferStopped:
             self.loading = false

--- a/README.md
+++ b/README.md
@@ -94,18 +94,6 @@ See [ISO18013View.swift](IOWalletProximityExample/IOWalletProximityExample/View/
 NFC Host Card Emulation is supported only on iOS 17.4+
 ```
 
-The library enforces NFC session time constraints:
-
-```swift
-public static let nfcHLESessionTimeRemaining: TimeInterval = 15
-public static let nfcHLESessionCoolDownTimeRemaining: TimeInterval = 15
-```
-
-- **Session Duration**: 15 seconds for active NFC HCE
-- **Cool-down Period**: 15 seconds mandatory wait before re-establishing NFC
-
-See [ISO18013View.swift](IOWalletProximityExample/IOWalletProximityExample/View/ISO18013View.swift#L65) for timer management implementation.
-
 ## Event Handling
 
 ### Delegate Protocol
@@ -323,8 +311,6 @@ try ISO18013.shared.lateNfcInitialization()
 The library throws errors as events (`.error(Error)`) and through exceptions:
 
 Common error scenarios:
-- `ProximityError.nfcAlreadyStarted` - NFC already active
-- `ProximityError.nfcCooldownNotExpired` - 15-second cool-down not elapsed
 - `ProximityError.nfcFailedToStart` - NFC initialization failed
 - CBOR encoding/decoding errors during response generation
 - Certificate verification failures


### PR DESCRIPTION
## Remove NFC cooldown logic and related documentation from ISO18013 implementation

## How to test

```
bundle install
cd IOWalletProximityExample
bundler exec pod update
```

Open IOWalletProximityExample\IOWalletProximityExample.xcworkspace using Xcode.

Select the options you want to enable. The six buttons allow for fast configuration of different 'engagement+datatransfer' combinations.

When you are ready press 'Start'.

If 'NFC Late Engagement' was selected you will see a button 'NFC' when you are ready to tap press it.
If 'NFC Late Engagement' was not selected host card emulation will start.

<img width="540" height="960" alt="nfc-proximity-no-cooldown" src="https://github.com/user-attachments/assets/388b7be7-0090-4994-94e9-1f31c6996331" />
