### PR TITLE
feat: [SIW-000] Add certificate data handling to device request processing

### DIFF
--- a/IOWalletProximity/IOWalletProximity/ISO18013.swift
+++ b/IOWalletProximity/IOWalletProximity/ISO18013.swift
@@ -44,7 +44,8 @@ public struct ISO18013DataTransferArgs: Sendable {
     public let request: [
         (docType: String,
          nameSpaces: [String: [String: Bool]],
-         isAuthenticated: Bool)
+         isAuthenticated: Bool,
+         certificateData: [String: String]?)
     ]?
 }
 

--- a/IOWalletProximity/IOWalletProximity/Proximity.swift
+++ b/IOWalletProximity/IOWalletProximity/Proximity.swift
@@ -73,7 +73,8 @@ public enum ProximityEvents {
     case onDocumentRequestReceived(request: [
         (docType: String,
          nameSpaces: [String: [String: Bool]],
-         isAuthenticated: Bool)
+         isAuthenticated: Bool,
+         certificateData: [String: String]?)
     ]?)
     
     //The device has received the termination flag from the verifier app
@@ -408,7 +409,7 @@ class Proximity: @unchecked Sendable {
     
     
     
-    func onRequest(request:  [(docType: String, nameSpaces: [String: [String: Bool]], isAuthenticated: Bool)]) {
+    func onRequest(request:  [(docType: String, nameSpaces: [String: [String: Bool]], isAuthenticated: Bool, certificateData: [String: String]?)]) {
         proximityHandler?(.onDocumentRequestReceived(request: request))
     }
     
@@ -416,9 +417,9 @@ class Proximity: @unchecked Sendable {
         onRequest(request: buildDeviceRequestJson(item: deviceRequest))
     }
     
-    func buildDeviceRequestJson(item: DeviceRequest) -> [(docType: String, nameSpaces: [String: [String: Bool]], isAuthenticated: Bool)] {
+    func buildDeviceRequestJson(item: DeviceRequest) -> [(docType: String, nameSpaces: [String: [String: Bool]], isAuthenticated: Bool, certificateData: [String: String]?)] {
         
-        var requestedDocuments: [(docType: String, nameSpaces: [String: [String: Bool]], isAuthenticated: Bool)] = []
+        var requestedDocuments: [(docType: String, nameSpaces: [String: [String: Bool]], isAuthenticated: Bool, certificateData: [String: String]?)] = []
         
         item.docRequests.forEach({
             request in
@@ -426,16 +427,18 @@ class Proximity: @unchecked Sendable {
             let isSignatureValid: Bool
             let isValidCertificateChain: Bool
             let authenticationMessage: String?
+            let certDetails: [String: String]?
             
             if let sessionEncryption = proximityListener?.sessionEncryption {
                 let iaca: [[SecCertificate]] = trustedCertificates
                 
-                (isSignatureValid, isValidCertificateChain, authenticationMessage) = MdocTransferHelpers.isDeviceRequestDocumentValid(docR: request, iaca: iaca, sessionEncryption: sessionEncryption)
+                (isSignatureValid, isValidCertificateChain, authenticationMessage, certDetails) = MdocTransferHelpers.isDeviceRequestDocumentValid(docR: request, iaca: iaca, sessionEncryption: sessionEncryption)
             }
             else {
                 isSignatureValid = false
                 isValidCertificateChain = false
                 authenticationMessage = nil
+                certDetails = nil
             }
             
             print("isSignatureValid: \(isSignatureValid)")
@@ -447,7 +450,7 @@ class Proximity: @unchecked Sendable {
             
             let isAuthenticated = isSignatureValid && isValidCertificateChain
             
-            requestedDocuments.append((docType: request.itemsRequest.docType, nameSpaces: getRequestedItems(request: request), isAuthenticated: isAuthenticated))
+            requestedDocuments.append((docType: request.itemsRequest.docType, nameSpaces: getRequestedItems(request: request), isAuthenticated: isAuthenticated, certificateData: certDetails))
         })
         
         return requestedDocuments

--- a/IOWalletProximity/IOWalletProximity/Proximity/BLE/MdocTransferHelpers.swift
+++ b/IOWalletProximity/IOWalletProximity/Proximity/BLE/MdocTransferHelpers.swift
@@ -8,7 +8,7 @@
 internal import X509
 internal import SwiftCBOR
 import Foundation
-
+internal import SwiftASN1
 
 class MdocTransferHelpers {
     /// Decrypt the contents of a data object and return a ``DeviceRequest`` object if the data represents a valid device request. If the data does not represent a valid device request, the function returns nil.
@@ -73,7 +73,7 @@ class MdocTransferHelpers {
            let x509 = try? X509.Certificate(derEncoded: [UInt8](certData)),
            let (isValidSignature, isValidCertificateChain, reasonFailure) = try? mdocAuth.validateReaderAuth(readerAuthCBOR: readerAuthRawCBOR, readerAuthCertificate: certData, itemsRequestRawData: docR.itemsRequestRawData!, readerAuthCertificateChain: docR.readerCertificateChain, rootCerts: iaca) {
             
-            let certDetails = distinguishedNameToJsonMap(x509.subject)
+            let certDetails = distinguishedNameToJsonMap(x509.issuer)
             
             
             if let reasonFailure {
@@ -94,6 +94,8 @@ class MdocTransferHelpers {
             rel.forEach({
                 att in
                 var attributeKey: String
+                var attributeValue: String = att.value.description
+                
                 switch att.type {
                     
                 case .RDNAttributeType.commonName:
@@ -112,17 +114,54 @@ class MdocTransferHelpers {
                     attributeKey = "STREET"
                 case .NameAttributes.serialNumber:
                     attributeKey = "SERIALNUMBER"
+                case .NameAttributes.emailAddress:
+                    attributeKey = "EMAIL"
+                    if let email = parseEmailField(att) {
+                        attributeValue = email
+                    }
                     
                 case let type:
                     attributeKey = String(describing: type)
                 }
                 
-                result[attributeKey] = att.value.description
+                result[attributeKey] = attributeValue
             })
         })
         
         return result
         
+    }
+    
+    
+    private static func parseEmailField(_ attribute: RelativeDistinguishedName.Attribute) -> String? {
+        //This is needed as the `RelativeDistinguishedName.Attribute.storage` field is internal. So we serialize and then deserialize manually the field to get the `ASN1Node`
+        do {
+            var serializer = DER.Serializer();
+            try attribute.serialize(into: &serializer);
+            let seq = try DER.parse(serializer.serializedBytes);
+            
+            if case .constructed(let nodes) = seq.content {
+                var iterator = nodes.makeIterator()
+                
+                // Skip the first child (the Object Identifier / OID)
+                _ = iterator.next()
+                
+                // The second child is the exact attribute value node you need
+                if let valueNode = iterator.next() {
+                    
+                    if let asnstr = try? ASN1IA5String(derEncoded: valueNode) {
+                        return String(asnstr)
+                    }
+                    
+                }
+            }
+            
+            
+        } catch {
+           
+        }
+        
+        return nil
     }
     
     public static func isDeviceRequestValid(deviceRequest: DeviceRequest, iaca: [[SecCertificate]], sessionEncryption: SessionEncryption) -> Bool {

--- a/IOWalletProximity/IOWalletProximity/Proximity/BLE/MdocTransferHelpers.swift
+++ b/IOWalletProximity/IOWalletProximity/Proximity/BLE/MdocTransferHelpers.swift
@@ -66,21 +66,64 @@ class MdocTransferHelpers {
         }
     }
     
-    public static func isDeviceRequestDocumentValid(docR: DocRequest, iaca: [[SecCertificate]], sessionEncryption: SessionEncryption) -> (isValidSignature: Bool, isValidCertificateChain: Bool, message: String?) {
+    public static func isDeviceRequestDocumentValid(docR: DocRequest, iaca: [[SecCertificate]], sessionEncryption: SessionEncryption) -> (isValidSignature: Bool, isValidCertificateChain: Bool, message: String?, certificateDetails: [String: String]? ) {
         let mdocAuth = MdocReaderAuthentication(transcript: sessionEncryption.transcript)
         if let readerAuthRawCBOR = docR.readerAuthRawCBOR,
            let certData = docR.readerCertificate,
            let x509 = try? X509.Certificate(derEncoded: [UInt8](certData)),
            let (isValidSignature, isValidCertificateChain, reasonFailure) = try? mdocAuth.validateReaderAuth(readerAuthCBOR: readerAuthRawCBOR, readerAuthCertificate: certData, itemsRequestRawData: docR.itemsRequestRawData!, readerAuthCertificateChain: docR.readerCertificateChain, rootCerts: iaca) {
+            
+            let certDetails = distinguishedNameToJsonMap(x509.subject)
+            
+            
             if let reasonFailure {
                 //Certificate root authentication failed
-                return (isValidSignature, isValidCertificateChain, reasonFailure)
+                return (isValidSignature, isValidCertificateChain, reasonFailure, certDetails)
             }
-            return (isValidSignature, isValidCertificateChain, reasonFailure)
+            return (isValidSignature, isValidCertificateChain, reasonFailure, certDetails)
         }
-        return (false, false, nil)
+        return (false, false, nil, nil)
     }
     
+    private static func distinguishedNameToJsonMap(_ dn: DistinguishedName) -> [String: String] {
+        
+        var result: [String: String] = [:]
+        
+        dn.forEach({
+            rel in
+            rel.forEach({
+                att in
+                var attributeKey: String
+                switch att.type {
+                    
+                case .RDNAttributeType.commonName:
+                    attributeKey = "CN"
+                case .RDNAttributeType.countryName:
+                    attributeKey = "C"
+                case .RDNAttributeType.localityName:
+                    attributeKey = "L"
+                case .RDNAttributeType.stateOrProvinceName:
+                    attributeKey = "ST"
+                case .RDNAttributeType.organizationName:
+                    attributeKey = "O"
+                case .RDNAttributeType.organizationalUnitName:
+                    attributeKey = "OU"
+                case .RDNAttributeType.streetAddress:
+                    attributeKey = "STREET"
+                case .NameAttributes.serialNumber:
+                    attributeKey = "SERIALNUMBER"
+                    
+                case let type:
+                    attributeKey = String(describing: type)
+                }
+                
+                result[attributeKey] = att.value.description
+            })
+        })
+        
+        return result
+        
+    }
     
     public static func isDeviceRequestValid(deviceRequest: DeviceRequest, iaca: [[SecCertificate]], sessionEncryption: SessionEncryption) -> Bool {
         if let docR = deviceRequest.docRequests.first {

--- a/IOWalletProximityExample/IOWalletProximityExample/View/ISO18013View.swift
+++ b/IOWalletProximityExample/IOWalletProximityExample/View/ISO18013View.swift
@@ -306,8 +306,8 @@ struct ISO18013View: View {
         }, set: {
             _ in
         })) {
-            let (isAuthenticated, request) = deviceRequestToMap(deviceRequest: dataTransferArgs!.request)
-            DeviceRequestAlert(isAuthenticated: isAuthenticated, requested: request, response: {
+            let (isAuthenticated, request, certDetails) = deviceRequestToMap(deviceRequest: dataTransferArgs!.request)
+            DeviceRequestAlert(isAuthenticated: isAuthenticated, requested: request, certificateData: certDetails, response: {
                 allowed, items in
                 
                 defer {
@@ -400,10 +400,10 @@ extension ISO18013View : ISO18013Delegate {
     private func completeDataTransferWithoutUserActions(deviceRequest: [
         (docType: String,
          nameSpaces: [String: [String: Bool]],
-         isAuthenticated: Bool)]?) {
+         isAuthenticated: Bool, certificateData: [String: String]?)]?) {
              
              
-             let (_, request) = deviceRequestToMap(deviceRequest: deviceRequest)
+             let (_, request, certDetails) = deviceRequestToMap(deviceRequest: deviceRequest)
              
              respondToDeviceRequest(true, items: acceptAllFields(deviceRequestMap: request))
              
@@ -412,9 +412,11 @@ extension ISO18013View : ISO18013Delegate {
     private func deviceRequestToMap(deviceRequest: [
         (docType: String,
          nameSpaces: [String: [String: Bool]],
-         isAuthenticated: Bool)
-    ]?) -> (isAuthenticated: Bool, request: [String: [String: [String]]]) {
+         isAuthenticated: Bool, certificateData: [String: String]?)
+    ]?) -> (isAuthenticated: Bool, request: [String: [String: [String]]], certificateData: [[String: String]?]) {
         var isAuthenticated: Bool = true
+        
+        var listOfCertDetails: [[String: String]?] = []
         
         var deviceRequestMap : [String: [String: [String]]] = [:]
         
@@ -432,9 +434,11 @@ extension ISO18013View : ISO18013Delegate {
             deviceRequestMap[item.docType] = subReq
             
             isAuthenticated = isAuthenticated && item.isAuthenticated
+            
+            listOfCertDetails.append(item.certificateData)
         })
         
-        return (isAuthenticated: isAuthenticated, request: deviceRequestMap)
+        return (isAuthenticated: isAuthenticated, request: deviceRequestMap, certificateData: listOfCertDetails)
     }
     
     private func acceptAllFields(deviceRequestMap: [String: [String: [String]]]?) -> [String: [String: [String: Bool]]]? {

--- a/IOWalletProximityExample/IOWalletProximityExample/Widget/DeviceRequestAlert.swift
+++ b/IOWalletProximityExample/IOWalletProximityExample/Widget/DeviceRequestAlert.swift
@@ -11,6 +11,8 @@ struct DeviceRequestAlert : View {
     var isAuthenticated: Bool = false
     var requested: [String: [String: [String]]]?
     
+    var certificateData: [[String: String]?]
+    
     @State private var allowed: [String: [String: [String: Bool]]]?
     
     var response: ((Bool, [String: [String: [String: Bool]]]?) -> Void)?
@@ -25,6 +27,13 @@ struct DeviceRequestAlert : View {
             ScrollView(.vertical) {
                 VStack {
                     Text("isAuthenticated: \(isAuthenticated ? "yes" : "no")").foregroundStyle(isAuthenticated ? Color.green : Color.red)
+                    
+                    ForEach(certificateData.compactMap({$0}), id: \.self) {
+                        detail in
+                        Text("\(detail)").foregroundStyle(isAuthenticated ? Color.green : Color.red)
+                    }
+                    
+                    
                 }
                 .padding(32)
                 .background(Color.white)
@@ -159,7 +168,7 @@ struct DeviceRequestAlert_Previews: PreviewProvider {
         var all: [String: [String: [String: Bool]]]? = [String: [String: [String: Bool]]]()
         
         
-        return DeviceRequestAlert(requested: value) { allowed, values in
+        return DeviceRequestAlert(requested: value, certificateData: [["CN" : "Example"]]) { allowed, values in
             print(allowed, values)
         }
     }


### PR DESCRIPTION
## Short description

Add certificate data handling to device request processing

```swift
public let request: [
        (docType: String,
         nameSpaces: [String: [String: Bool]],
         isAuthenticated: Bool,
         certificateData: [String: String]?)
]?
```

Example:

```json
[
  {
    "docType": "eu.europa.ec.eudi.pid.1",
    "nameSpaces": {
      "eu.europa.ec.eudi.pid.1": {
        "age_over_18": false
      }
    },
    "isAuthenticated": false,
    "certificateData": {
      "O": "EUDI Wallet Reference Implementation",
      "CN": "EUDI Proximity Verifier",
      "SERIALNUMBER": "001",
      "C": "UT"
    }
  }
]
```

## How to test

Open IOWalletProximityExample\IOWalletProximityExample.xcworkspace using Xcode. 
Perform proximity authentication and verify if the certificate data is returned in the `ISO18013DataTransferArgs` struct

<img width="1284" height="2778" alt="Image (11)" src="https://github.com/user-attachments/assets/87849a10-bf23-4e19-bfab-5d56cec6648d" />

