### PR TITLE
feat: [SIW-000] Enhance NFC emulation handling

### DIFF
--- a/IOWalletProximity/IOWalletProximity/Proximity/LibIso18013Proximity.swift
+++ b/IOWalletProximity/IOWalletProximity/Proximity/LibIso18013Proximity.swift
@@ -52,9 +52,13 @@ class LibIso18013Proximity: @unchecked Sendable {
     
     private var retrivalMethodsStarted: Bool = false
     
+    private var _nfcEmulationInProgress: Bool = false
+    
     @available(iOS 17.4, *)
     public func startNfcDataTransfer(_ allowEngagement: Bool = false) async throws -> Bool {
         print("startNfcDataTransfer allowEngagement: \(allowEngagement)")
+        
+        print("_nfcEmulationInProgress: \(_nfcEmulationInProgress)")
         do {
             guard let deviceEngagement = self.deviceEngagement else {
                 return false
@@ -74,8 +78,21 @@ class LibIso18013Proximity: @unchecked Sendable {
                 status in
                 
                 if (status == .onEngagementDone) {
-                    print("onEngagementDone")
+                    print("nfc: onEngagementDone")
                     self.bleServer?.handOver = nfc.handOver!
+                }
+                
+                if (status == .onStop) {
+                    print("nfc: onStop")
+                    self.retrivalMethodsStarted = false
+                }
+                
+                if (status == .onStart) {
+                    self._nfcEmulationInProgress = true
+                }
+                
+                if (status == .onStop) {
+                    self._nfcEmulationInProgress = false
                 }
                 
                 self.nfcHandler?(status)
@@ -88,6 +105,7 @@ class LibIso18013Proximity: @unchecked Sendable {
             let success = try await nfc.start()
             
             if (success) {
+                self._nfcEmulationInProgress = true
                 nfcHandler?(.onStart)
             }
             else {
@@ -118,6 +136,9 @@ class LibIso18013Proximity: @unchecked Sendable {
     @available(iOS 17.4, *)
     public func startNfcEngagement(_ deviceRetrivalMethods: [ISO18013DataTransferMode] = [.ble, .nfc], isLateNfc: Bool, allowEngagement: Bool) async throws -> Bool {
         print("startNfcEngagement")
+        
+        print("_nfcEmulationInProgress: \(_nfcEmulationInProgress)")
+        
         do {
         
             try initDeviceEngagement(deviceRetrivalMethods)
@@ -140,6 +161,14 @@ class LibIso18013Proximity: @unchecked Sendable {
             nfc.nfcHandler = {
                 status in
                 
+                if (status == .onStart) {
+                    self._nfcEmulationInProgress = true
+                }
+                
+                if (status == .onStop) {
+                    self._nfcEmulationInProgress = false
+                }
+                
                 if (status == .onEngagementDone) {
                     self.bleServer?.handOver = nfc.handOver!
                 }
@@ -151,6 +180,8 @@ class LibIso18013Proximity: @unchecked Sendable {
             _nfc = nfc
             
             //bleServer?.handOver = nfc.handOver
+            
+            
             
             let success = try await nfc.start()
             
@@ -209,6 +240,7 @@ class LibIso18013Proximity: @unchecked Sendable {
     private func startRetrivalMethods(_ deviceRetrivalMethods: [ISO18013DataTransferMode], _ allowEngagement: Bool, isNfcLateEngagement: Bool = false) {
         
         print("startRetrivalMethods allowEngagement: \(allowEngagement) isLate: \(isNfcLateEngagement)")
+        print("_nfcEmulationInProgress: \(_nfcEmulationInProgress)")
         
         if retrivalMethodsStarted {
             print("retrivalMethods already started")
@@ -216,7 +248,13 @@ class LibIso18013Proximity: @unchecked Sendable {
             if isNfcLateEngagement {
                 print("retrivalMethods already started and isNfcLateEngagement")
                 return
+            } else {
+                
+                if _nfcEmulationInProgress {
+                    return
+                }
             }
+            
             
            
         }
@@ -235,7 +273,9 @@ class LibIso18013Proximity: @unchecked Sendable {
                     print("isNfcLateEngagement: \(isNfcLateEngagement)")
                     if !isNfcLateEngagement {
                         if #available(iOS 17.4, *) {
+                            self._nfcEmulationInProgress = true
                             Task {
+                                
                                 try await startNfcDataTransfer(allowEngagement)
                             }
                         } else {


### PR DESCRIPTION
## Fix "Session Already Started" crash when multiple engagement are selected.

## How to test

Press start with all the checks selected except "Nfc Late Engagement"

<img width="1206" height="2622" alt="immagine" src="https://github.com/user-attachments/assets/aa0c3981-f3b7-44f3-9826-c91a4dad3c40" />
